### PR TITLE
fix: address codebase review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CICD
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.59.0"
+  MIN_SUPPORTED_RUST_VERSION: "1.86.0"
   CARGO_TERM_COLOR: "always"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
@@ -29,15 +29,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-
-      - name: Install xcb
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            libgl1-mesa-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libx11-xcb-dev
 
       - name: Install rust toolchain (v${{ env.MIN_SUPPORTED_RUST_VERSION }})
         uses: dtolnay/rust-toolchain@master
@@ -75,16 +66,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-
-      - name: Install xcb
-        if: startsWith(matrix.job.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            libgl1-mesa-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libx11-xcb-dev
 
       - name: Extract crate information
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+- Copied text now survives `cb` exiting on Linux. X11 and Wayland clipboards
+  only live as long as the program that set them, so `cb` leaves a background
+  process serving the text until something else is copied.
+- Native Wayland support, alongside X11.
+- Piped input and files keep their leading whitespace. Only one trailing
+  newline is dropped, and printing adds it back, so copying and printing a
+  file reproduces it exactly.
+- `cb FILE` copies the file even when stdin is not a terminal, such as in
+  scripts and editor tasks, instead of copying empty input.
+- Add `--help` and `--version`.
+- Errors are reported as messages with exit status 1, or 2 for invalid
+  arguments, instead of panics.
+- Replace the unmaintained `atty` (RUSTSEC-2021-0145, RUSTSEC-2024-0375) with
+  `std::io::IsTerminal`, and `copypasta` with `arboard`.
+- Building no longer needs the X11 development libraries.
+- Minimum supported Rust version is now 1.86.
+
 ## v0.0.1
 
 initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,33 +3,38 @@
 version = 3
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "arboard"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
-name = "block"
-version = "0.1.6"
+name = "cc"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -41,41 +46,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "clipboard-cli"
 version = "0.0.1"
 dependencies = [
- "atty",
- "copypasta",
+ "arboard",
 ]
 
 [[package]]
 name = "clipboard-win"
-version = "3.1.1"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
- "lazy-bytes-cast",
- "winapi",
+ "error-code",
 ]
 
 [[package]]
-name = "copypasta"
-version = "0.7.1"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4423d79fed83ebd9ab81ec21fa97144300a961782158287dc9bf7eddac37ff0b"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "clipboard-win",
- "objc",
- "objc-foundation",
- "objc_id",
- "smithay-clipboard",
- "x11-clipboard",
-]
-
-[[package]]
-name = "dlib"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
-dependencies = [
- "libloading",
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -85,40 +75,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "lazy-bytes-cast"
-version = "5.0.1"
+name = "error-code"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "find-msvc-tools"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libloading"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "cfg-if",
- "winapi",
+ "scopeguard",
 ]
 
 [[package]]
@@ -131,100 +180,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memmap2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "nom"
-version = "7.1.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "malloc_buf",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
+name = "objc2-app-kit"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "block",
- "objc",
- "objc_id",
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "objc",
+ "bitflags",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.0"
+name = "objc2-core-graphics"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
 
 [[package]]
 name = "pkg-config"
@@ -234,36 +325,64 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
+name = "redox_syscall"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
@@ -272,31 +391,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "smithay-client-toolkit"
-version = "0.16.0"
+name = "syn"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
- "bitflags",
- "dlib",
- "lazy_static",
- "log",
- "memmap2",
- "nix",
- "pkg-config",
- "wayland-client",
- "wayland-cursor",
- "wayland-protocols",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "smithay-clipboard"
-version = "0.6.6"
+name = "thiserror"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "smithay-client-toolkit",
- "wayland-client",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -306,131 +439,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
-name = "wayland-client"
-version = "0.29.5"
+name = "wayland-backend"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
- "bitflags",
+ "cc",
  "downcast-rs",
- "libc",
- "nix",
- "scoped-tls",
- "wayland-commons",
- "wayland-scanner",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-commons"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
-dependencies = [
- "nix",
- "once_cell",
+ "rustix",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
-name = "wayland-cursor"
-version = "0.29.5"
+name = "wayland-client"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
- "nix",
- "wayland-client",
- "xcursor",
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.29.5"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags",
+ "wayland-backend",
  "wayland-client",
- "wayland-commons",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.29.5"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
+ "quick-xml",
  "quote",
- "xml-rs",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.29.5"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
- "dlib",
- "lazy_static",
  "pkg-config",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x11-clipboard"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473068b7b80ac86a18328824f1054e5e007898c47b5bbc281bd7abe32bc3653c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "xcb",
+ "windows-link",
 ]
 
 [[package]]
-name = "xcb"
-version = "0.10.1"
+name = "windows-targets"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771e2b996df720cd1c6dd9ff90f62d91698fd3610cc078388d0564bdd6622a9c"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
 dependencies = [
  "libc",
  "log",
- "quick-xml",
+ "os_pipe",
+ "rustix",
+ "thiserror",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
-name = "xcursor"
-version = "0.3.4"
+name = "x11rb"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
- "nom",
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.4"
+name = "x11rb-protocol"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "clipboard-cli"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
+rust-version = "1.86"
 authors = ["Amila Welihinda <amilajack@gmail.com>"]
 license = "MIT"
 description = "A better command line clipboard"
@@ -16,5 +17,4 @@ name = "cb"
 path = "src/main.rs"
 
 [dependencies]
-atty = "0.2"
-copypasta = "0.7.1"
+arboard = { version = "3.6", default-features = false, features = ["wayland-data-control"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cargo install clipboard-cli
 ## Usage
 
 ```bash
-# Copy file to clipbard
+# Copy file to clipboard
 cb package.json
 
 # Pipe to clipboard
@@ -25,6 +25,9 @@ cb | vim -
 
 # Search clipboard contents
 cb | grep hello
+
+# Show all options
+cb --help
 ```
 
 ## Upcoming
@@ -45,4 +48,4 @@ cb p 1
 | Single Command | ✅            | ❌              | ✅              | ✅                |
 | Cross Platform | ✅            | ❌ (macOS only) | ❌ (linux only) | ❌ (windows only) |
 | Simple API     | ✅            | ✅              | ❌              | ✅                |
-| History Peak   | ✅            | ❌              | ❌              | ❌                |
+| History Peek   | 🚧 planned    | ❌              | ❌              | ❌                |

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -1,24 +1,57 @@
-.TH "clipboard" "1" "January 2022" "" ""
+.TH "CB" "1" "September 2026" "" "User Commands"
 .hy
 .SH NAME
 .PP
-clipboard - a better cli clipboard
-.SH Examples
+cb \- a better command line clipboard
+.SH SYNOPSIS
 .PP
-\f[B]Copy to os clipbard\f[R]
+\f[B]cb\f[R] [\f[I]FILE\f[R]]
+.SH DESCRIPTION
+.PP
+Copy \f[I]FILE\f[R], or whatever is piped in, to the system clipboard.
+With no \f[I]FILE\f[R] and nothing piped in, print the clipboard.
+.PP
+One trailing newline is dropped when copying and added back when
+printing, so copying a file and printing the clipboard reproduces it.
+.PP
+On Linux, X11 and Wayland clipboards only live as long as the program
+that set them, so \f[B]cb\f[R] leaves a background process serving the
+copied text until another program copies something.
+.SH OPTIONS
+.TP
+\f[B]\-h\f[R], \f[B]\-\-help\f[R]
+Print help.
+.TP
+\f[B]\-V\f[R], \f[B]\-\-version\f[R]
+Print version.
+.SH EXAMPLES
+.PP
+\f[B]Copy a file to the clipboard\f[R]
 .PP
 cb package.json
 .PP
-\f[B]Pipe to os clipboard\f[R]
+\f[B]Pipe to the clipboard\f[R]
 .PP
-cat package.json | cb echo `Hello World!' | cb
+cat package.json | cb
+.PP
+echo \[aq]Hello World!\[aq] | cb
 .PP
 \f[B]Read clipboard contents\f[R]
 .PP
-cb | vim -
+cb | vim \-
 .PP
 \f[B]Search clipboard contents\f[R]
 .PP
 cb | grep hello
+.SH EXIT STATUS
+.TP
+0
+Success.
+.TP
+1
+The file could not be read or the clipboard could not be accessed.
+.TP
+2
+Invalid arguments.
 .SH AUTHORS
 Amila Welihinda.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,43 +1,309 @@
-use atty::Stream;
-use copypasta::{ClipboardContext, ClipboardProvider};
-use std::env::args;
+use std::env;
+use std::ffi::OsString;
 use std::fs;
-use std::io::{stdin, Read};
+use std::io::{self, IsTerminal, Read, Write};
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-fn write<T: AsRef<str>>(content: T) {
-    let mut ctx: ClipboardContext = ClipboardContext::new().unwrap();
-    ctx.set_contents(content.as_ref().to_owned()).unwrap();
+use arboard::Clipboard;
+
+const USAGE: &str = "\
+Usage: cb [FILE]
+
+Copy FILE, or whatever is piped in, to the system clipboard.
+With no FILE and nothing piped in, print the clipboard.
+
+Examples:
+  cb package.json    Copy a file
+  git diff | cb      Copy piped input
+  cb | grep hello    Search the clipboard
+
+Options:
+  -h, --help         Print help
+  -V, --version      Print version
+";
+
+/// Set in the environment of the background process that serves the clipboard.
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+))]
+const SERVE_ENV: &str = "CB_SERVE_CLIPBOARD";
+
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    Help,
+    Version,
+    Print,
+    CopyFile(PathBuf),
+    CopyStdin,
 }
 
-fn print() {
-    let mut ctx: ClipboardContext = ClipboardContext::new().unwrap();
-    println!("{}", ctx.get_contents().unwrap());
-}
-
-fn main() {
-    // Handle `cb ...` stdin cases
-    // echo 'foo' | cb
-    if atty::isnt(Stream::Stdin) {
-        let mut buffer = String::new();
-        stdin().read_to_string(&mut buffer).unwrap();
-        write(buffer.trim());
-        return;
+/// Decides what to do from the arguments (excluding the program name).
+///
+/// An explicit file always wins over stdin, so `cb notes.txt` behaves the same
+/// in a script or IDE task, where stdin is not a terminal, as it does at a prompt.
+fn parse_args<I>(args: I, stdin_is_terminal: bool) -> Result<Action, String>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
+    let first = args.next();
+    if let Some(extra) = args.next() {
+        return Err(format!("unexpected argument '{}'", extra.to_string_lossy()));
     }
 
-    // Handle `cb ...` stdout cases
-    match args().len() {
-        // Case of `cb`
-        1 => return print(),
-        // Case of `cb my-file`
-        2 => match args().nth(1) {
-            Some(path) => {
-                let abs_path = PathBuf::from(path).canonicalize().unwrap();
-                let res = fs::read_to_string(abs_path).expect("file does not exist");
-                return write(res);
+    let arg = match first {
+        Some(arg) => arg,
+        None if stdin_is_terminal => return Ok(Action::Print),
+        None => return Ok(Action::CopyStdin),
+    };
+    match arg.to_str() {
+        Some("-h" | "--help") => Ok(Action::Help),
+        Some("-V" | "--version") => Ok(Action::Version),
+        Some(flag) if flag.len() > 1 && flag.starts_with('-') => {
+            Err(format!("unknown option '{}'", flag))
+        }
+        _ => Ok(Action::CopyFile(PathBuf::from(arg))),
+    }
+}
+
+/// Drops one trailing line ending.
+///
+/// Commands like `echo` end their output with a newline nobody means to paste.
+/// `print` adds it back, so `cb < a; cb > b` leaves `b` identical to `a`.
+/// Everything else, including leading whitespace, is part of the content.
+fn strip_trailing_newline(text: &str) -> &str {
+    text.strip_suffix("\r\n")
+        .or_else(|| text.strip_suffix('\n'))
+        .unwrap_or(text)
+}
+
+fn run(action: Action) -> Result<(), String> {
+    match action {
+        Action::Help => {
+            print!("{}", USAGE);
+            Ok(())
+        }
+        Action::Version => {
+            println!("cb {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        Action::Print => print(),
+        Action::CopyFile(path) => {
+            let text =
+                fs::read_to_string(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
+            copy(strip_trailing_newline(&text))
+        }
+        Action::CopyStdin => {
+            let mut text = String::new();
+            io::stdin()
+                .read_to_string(&mut text)
+                .map_err(|e| format!("stdin: {}", e))?;
+            copy(strip_trailing_newline(&text))
+        }
+    }
+}
+
+fn print() -> Result<(), String> {
+    let text = Clipboard::new()
+        .and_then(|mut clipboard| clipboard.get_text())
+        .map_err(|e| e.to_string())?;
+    let mut stdout = io::stdout().lock();
+    match writeln!(stdout, "{}", text).and_then(|()| stdout.flush()) {
+        // The reader went away early, as with `cb | head -1`; that's not an error.
+        Err(e) if e.kind() != io::ErrorKind::BrokenPipe => Err(e.to_string()),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(not(all(
+    unix,
+    not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+)))]
+fn copy(text: &str) -> Result<(), String> {
+    Clipboard::new()
+        .and_then(|mut clipboard| clipboard.set_text(text))
+        .map_err(|e| e.to_string())
+}
+
+/// On X11 and Wayland the copied text lives in the process that set it and
+/// vanishes when that process exits. Hand it to a detached copy of ourselves
+/// that keeps serving it until another program copies something.
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+))]
+fn copy(text: &str) -> Result<(), String> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let exe = env::current_exe().map_err(|e| e.to_string())?;
+    // The server gets its own pipes rather than ours, so that `cb f | cat` and
+    // `$(cb f)` finish immediately instead of waiting for it to exit. Its own
+    // process group keeps a Ctrl-C at the prompt from reaching it.
+    let mut child = Command::new(exe)
+        .env(SERVE_ENV, "1")
+        .current_dir("/")
+        .process_group(0)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to start clipboard server: {}", e))?;
+
+    let sent = child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(text.as_bytes());
+
+    // One byte means the server connected and is taking over; EOF means it failed.
+    let mut ready = [0; 1];
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    if sent.is_ok() && stdout.read_exact(&mut ready).is_ok() {
+        return Ok(());
+    }
+
+    child.kill().ok();
+    let mut message = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr is piped")
+        .read_to_string(&mut message)
+        .ok();
+    child.wait().ok();
+    match (message.trim_end(), sent) {
+        ("", Err(e)) => Err(format!("failed to start clipboard server: {}", e)),
+        ("", Ok(())) => Err("clipboard server exited unexpectedly".to_owned()),
+        (message, _) => Err(message.to_owned()),
+    }
+}
+
+/// Runs in the background process started by `copy`.
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+))]
+fn serve() -> Result<(), String> {
+    use arboard::SetExtLinux;
+
+    let mut text = String::new();
+    io::stdin()
+        .read_to_string(&mut text)
+        .map_err(|e| e.to_string())?;
+    let mut clipboard = Clipboard::new().map_err(|e| e.to_string())?;
+
+    // Connecting to the display is what fails in practice (no X11 or Wayland
+    // session, say over SSH), so that's the point to tell the parent it can exit.
+    let mut stdout = io::stdout();
+    stdout
+        .write_all(b"\n")
+        .and_then(|()| stdout.flush())
+        .map_err(|e| e.to_string())?;
+
+    // Blocks until another program takes over the clipboard.
+    clipboard.set().wait().text(text).map_err(|e| e.to_string())
+}
+
+fn main() -> ExitCode {
+    #[cfg(all(
+        unix,
+        not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+    ))]
+    if env::var_os(SERVE_ENV).is_some() {
+        return match serve() {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(message) => {
+                // Read by the parent, which adds its own `cb:` prefix.
+                eprintln!("{}", message);
+                ExitCode::FAILURE
             }
-            None => {}
-        },
-        _ => panic!("unexpected number of args"),
+        };
+    }
+
+    let action = match parse_args(env::args_os().skip(1), io::stdin().is_terminal()) {
+        Ok(action) => action,
+        Err(message) => {
+            eprintln!("cb: {}\nTry 'cb --help' for more information.", message);
+            return ExitCode::from(2);
+        }
+    };
+    match run(action) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("cb: {}", message);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str], stdin_is_terminal: bool) -> Result<Action, String> {
+        parse_args(args.iter().map(OsString::from), stdin_is_terminal)
+    }
+
+    #[test]
+    fn no_args_at_a_terminal_prints() {
+        assert_eq!(parse(&[], true), Ok(Action::Print));
+    }
+
+    #[test]
+    fn no_args_with_piped_input_copies_stdin() {
+        assert_eq!(parse(&[], false), Ok(Action::CopyStdin));
+    }
+
+    #[test]
+    fn file_argument_wins_over_piped_input() {
+        let expected = Ok(Action::CopyFile(PathBuf::from("notes.txt")));
+        assert_eq!(parse(&["notes.txt"], true), expected);
+        assert_eq!(parse(&["notes.txt"], false), expected);
+    }
+
+    #[test]
+    fn help_and_version_flags() {
+        for flag in ["-h", "--help"] {
+            assert_eq!(parse(&[flag], true), Ok(Action::Help));
+        }
+        for flag in ["-V", "--version"] {
+            assert_eq!(parse(&[flag], true), Ok(Action::Version));
+        }
+    }
+
+    #[test]
+    fn unknown_option_is_rejected() {
+        assert_eq!(
+            parse(&["--bogus"], true),
+            Err("unknown option '--bogus'".into())
+        );
+    }
+
+    #[test]
+    fn extra_arguments_are_rejected() {
+        assert_eq!(
+            parse(&["a", "b"], true),
+            Err("unexpected argument 'b'".into())
+        );
+    }
+
+    #[test]
+    fn strips_exactly_one_trailing_newline() {
+        assert_eq!(strip_trailing_newline("hello\n"), "hello");
+        assert_eq!(strip_trailing_newline("hello\r\n"), "hello");
+        assert_eq!(strip_trailing_newline("hello\n\n"), "hello\n");
+        assert_eq!(strip_trailing_newline("hello"), "hello");
+        assert_eq!(strip_trailing_newline(""), "");
+    }
+
+    #[test]
+    fn keeps_leading_and_inner_whitespace() {
+        assert_eq!(
+            strip_trailing_newline("    indented\n  code \n"),
+            "    indented\n  code "
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,61 @@
+//! Exercises the binary without touching the system clipboard, so these run
+//! on headless CI machines.
+
+use std::process::{Command, Output};
+
+fn cb(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cb"))
+        .args(args)
+        .output()
+        .expect("failed to run cb")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn help_prints_usage() {
+    for flag in ["-h", "--help"] {
+        let output = cb(&[flag]);
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(stdout(&output).starts_with("Usage: cb [FILE]"));
+    }
+}
+
+#[test]
+fn version_prints_the_crate_version() {
+    let output = cb(&["--version"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        stdout(&output),
+        format!("cb {}\n", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn too_many_arguments_is_a_usage_error() {
+    let output = cb(&["a", "b"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("unexpected argument 'b'"));
+}
+
+#[test]
+fn unknown_option_is_a_usage_error() {
+    let output = cb(&["--bogus"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("unknown option '--bogus'"));
+}
+
+#[test]
+fn missing_file_names_the_path_instead_of_panicking() {
+    let output = cb(&["does-not-exist.txt"]);
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = stderr(&output);
+    assert!(stderr.starts_with("cb: does-not-exist.txt: "), "{}", stderr);
+    assert!(!stderr.contains("panicked"), "{}", stderr);
+}


### PR DESCRIPTION
Fixes every finding from the codebase review, in one PR as requested. `src/main.rs` is effectively rewritten, but it is still a single small file.

## What changed

| # | Finding | Fix |
| --- | --- | --- |
| 1 | On Linux, copied text vanished when `cb` exited | A detached copy of `cb` serves the text until something else is copied |
| 2 | `trim()` stripped leading whitespace from piped input | Drop exactly one trailing newline; printing adds it back |
| 3 | Missing file panicked before the friendly message could show | Errors are messages with exit status 1 |
| 4 | No `--help` or `--version`; `cb --help` panicked | Both added; bad arguments exit 2 |
| 5 | `atty` is unsound on Windows and unmaintained | `std::io::IsTerminal` |
| 6 | `copypasta` 0.7 pinned a `quick-xml` a future rustc rejects | `arboard` 3.6 |
| 7 | Docs claimed history shipped; typos; man page merged two examples | Fixed; history marked planned; options and exit status documented |
| 8 | No tests | 8 unit and 5 CLI tests |

### How #1 works

X11 and Wayland clipboards are served by the process that set them, so the text disappeared as soon as `cb` exited, unless a clipboard manager grabbed it first. Now `cb` starts a detached copy of itself and passes it the text. That process holds the clipboard via arboard's `SetExtLinux::wait()` and exits once another program copies something.

- It has its own pipes, so `cb f | cat` and `$(cb f)` return immediately.
- It runs in its own process group, so Ctrl-C at the prompt doesn't reach it.
- It tells the parent once it has connected to the display. Failures such as having no X11 or Wayland session over SSH are still reported as errors rather than silently dropped.

macOS and Windows keep the clipboard after exit, so they copy directly.

## Behaviour changes to be aware of

- **On Linux, a `cb` process stays running** after a copy, until the next copy. This is what `xclip` and `wl-copy` do too.
- **Copying a file now drops one trailing newline**, like stdin always did. Previously files were copied verbatim. This makes `cb f` and `cb < f` identical, and `cb f; cb > g` reproduces `f` byte for byte.
- **`cb FILE` now wins over stdin.** Previously, if stdin was not a terminal (scripts, editor tasks, cron), `cb FILE` ignored the file and copied empty input.
- `println!` on output is kept on purpose. The review suggested `print!`, but with one newline dropped on input, `println!` is what makes the round trip exact.

## MSRV: 1.59 → 1.86

This is set by the Wayland support, not by `arboard`, which needs only 1.71. Every crate that needs more than that — `wayland-protocols` (1.86), `tree_magic_mini`, `indexmap` and `hashbrown` (edition 2024), and `quick-xml` (1.79) — comes in through `wl-clipboard-rs`. That crate is only pulled in by the `wayland-data-control` feature. Without that feature, Wayland sessions fall back to XWayland and the MSRV would be 1.71. The macOS and Windows dependencies top out at 1.71.

Pinning older transitive versions to hold 1.71 wouldn't help. `cargo install` ignores the lockfile, and Dependabot would bump them back.

`arboard` reaches X11 through the pure-Rust `x11rb`, so building needs no system libraries. CI no longer installs `libxcb-*-dev`.

## Verification

- `cargo fmt --check`, `cargo clippy --locked --all-targets --all-features` (no warnings), and `cargo test --locked` (13/13) all pass on 1.86.0 and on stable.
- 1.71.0 fails, as expected: its cargo can't parse edition 2024.
- It built and linked on a machine with no X11 dev libraries installed.
- Failure paths were run against the real binary with `DISPLAY`, `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR` unset: piped copy, file copy and print. Each exited 1 with a single `cb: …` message, nothing hung, and no `cb` process was left behind. This exercises the full parent/child hand-off, including relaying the child's error.

**Not verified:** the Linux success path against a live X11 or Wayland session, since there was none available. To check it, run `echo hi | cb`, then paste into another app after the command returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan