### PR TITLE
ci: publish to crates.io with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,82 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Publishes to crates.io, then tags and creates the GitHub release, whenever
+  # the version in Cargo.toml isn't published yet, i.e. after a release PR merges.
+  release-plz-release:
+    name: Release-plz release
+    if: github.repository_owner == 'amilajack'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      pull-requests: read
+      # Trusted publishing: release-plz trades this OIDC token for a short-lived
+      # crates.io token, so no CARGO_REGISTRY_TOKEN secret is stored anywhere.
+      id-token: write
+      # Lets the job start the CICD workflow on the new tag; see the last step.
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # A tag pushed with GITHUB_TOKEN doesn't trigger other workflows, so CICD
+      # would never build the release binaries. workflow_dispatch is the one event
+      # GITHUB_TOKEN may trigger: run CICD on the new tag, where it builds the
+      # binaries and attaches them to the release that release-plz just created.
+      - name: Build and attach release binaries
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          for tag in $(jq -r '.[].tag' <<< "$RELEASES"); do
+            gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$tag"
+          done
+
+  # Opens or updates a PR that bumps the version by semver, based on the
+  # conventional commits since the last release, and updates CHANGELOG.md.
+  release-plz-pr:
+    name: Release-plz PR
+    if: github.repository_owner == 'amilajack'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## Unreleased
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Details
 
 - Copied text now survives `cb` exiting on Linux. X11 and Wayland clipboards
   only live as long as the program that set them, so `cb` leaves a background
@@ -17,6 +26,6 @@
 - Building no longer needs the X11 development libraries.
 - Minimum supported Rust version is now 1.86.
 
-## v0.0.1
+## [0.0.1] - 2022-02-21
 
-initial release
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ cb peek 1
 cb p 1
 ```
 
+## Releasing
+
+Releases are automated with [release-plz](https://release-plz.dev). Write commit
+messages as [Conventional Commits](https://www.conventionalcommits.org): `fix:`,
+`feat:`, and `feat!:` or a `BREAKING CHANGE:` footer for breaking changes.
+
+Every merge to `main` opens or updates a release PR that bumps the version by
+semver and updates `CHANGELOG.md`. Merging that PR publishes the crate to
+crates.io, tags the release, and attaches the binaries built by CI.
+`ci`, `docs`, `chore`, `build`, `style` and `test` commits are left out of the
+changelog.
+
 ## Comparison
 
 |                | **clipboard** | pbcopy/pbpaste  | xclip           | clip              |

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,15 @@
+[changelog]
+# Never drop a breaking change, even if a parser below would skip it.
+protect_breaking_commits = true
+commit_parsers = [
+    # CI, build, docs, style, test and chore commits don't change what users get.
+    { message = "^(ci|build|chore|docs|style|test)", skip = true },
+    { message = '^[a-z]+\(ci\)', skip = true },
+    # release-plz's defaults.
+    { message = "^feat", group = "added" },
+    { message = "^changed", group = "changed" },
+    { message = "^deprecated", group = "deprecated" },
+    { message = "^fix", group = "fixed" },
+    { message = "^security", group = "security" },
+    { message = "^.*", group = "other" },
+]


### PR DESCRIPTION
Automates semver releases to crates.io with [release-plz](https://release-plz.dev).

> [!IMPORTANT]
> **Stacked on #15.** Merge #15 first, then change this PR's base to `main` before merging it. #15 has to land first: `cargo publish` builds the crate, and before #15 that needs X11 system libraries the runner doesn't have. Also, `main` doesn't delete merged branches, so GitHub won't retarget this PR on its own.

## How releasing works after this

1. You merge PRs to `main` with [Conventional Commit](https://www.conventionalcommits.org) messages.
2. release-plz opens or updates a **release PR**. It bumps `Cargo.toml` by semver, based on the commits since the last tag, and adds a `CHANGELOG.md` section.
3. Merging the release PR **publishes to crates.io**, pushes the `vX.Y.Z` tag and creates the GitHub release.
4. The same job then dispatches the existing CICD workflow on that tag. CICD builds the three ARM binaries and the `.deb` and attaches them to the release.

Step 4 exists because a tag pushed with `GITHUB_TOKEN` doesn't trigger other workflows, so the existing tag-triggered build would never run. A manual workflow dispatch is the one event `GITHUB_TOKEN` is allowed to start.

## One-time setup you need to do

**Configure trusted publishing on crates.io.** Without it, the publish step fails; nothing else is needed, and no secret has to be stored.

`clipboard-cli` → Settings → Trusted Publishing → Add → GitHub:

| Field | Value |
| --- | --- |
| Repository owner | `amilajack` |
| Repository name | `clipboard` |
| Workflow filename | `release-plz.yml` |
| Environment | *(leave empty)* |

The repo already lets Actions create pull requests, so no GitHub settings need to change.

## Changes

- **`.github/workflows/release-plz.yml`** — two jobs, both on ARM runners and restricted to this repo so forks don't run them. `release-plz-release` publishes, tags and dispatches the binary build. It has `id-token: write` for trusted publishing and `actions: write` for the dispatch. `release-plz-pr` maintains the release PR.
- **`release-plz.toml`** — leaves `ci`, `build`, `chore`, `docs`, `style` and `test` commits, plus anything scoped `(ci)`, out of the changelog. Breaking changes are never dropped.
- **`CHANGELOG.md`** — converted to the Keep a Changelog layout release-plz expects. #15's hand-written notes stay under `## [Unreleased]`.
- **`README.md`** — a short "Releasing" section covering the commit conventions and the flow above.

## Things to know

- **The crate will stay on 0.0.x until you bump it by hand.** On 0.0.x, release-plz only ever bumps the patch number: a `feat!:` breaking change and a `feat:` both gave `0.0.2` in dry runs. To move to proper 0.x semver, set `version = "0.1.0"` in `Cargo.toml` on `main`. release-plz keeps a manual bump ("local version (0.1.0) > registry version (0.0.1). Only changelog will be updated"). After that, breaking changes bump the minor version and everything else bumps the patch.
- **The first release PR will propose `0.0.2`.** It lists #15 under Fixed, the pre-existing non-conventional commits (README tweaks, "bump deps") under Other, and #15's hand-written notes under Details.
- **CI won't run on release PRs.** GitHub doesn't start workflows for PRs opened with `GITHUB_TOKEN`. Release PRs only touch the version, the changelog and `Cargo.lock`, and the code in them has already passed CI on `main`. If you want checks on them, the fix is a GitHub App or personal access token for the `release-plz-pr` job.

## Verification

- **release-plz dry runs** used release-plz 0.3.165 on scratch clones. Each ran `release-plz update` against both `main` and this branch's exact files; the second run above produced the changelog shown below.
- **The changelog parsers work:** `ci:`, `docs:` and `fix(ci):` commits were left out, and #15's notes landed inside the `0.0.2` section.
- **A manual `0.1.0` bump is kept.**
- **`actionlint`** (1.7.12) passes on `release-plz.yml` and `ci.yml`.
- **Not verified:** the release workflow itself, because it only runs on pushes to `main`. The first real run will be the merge of this PR, which opens the first release PR and publishes nothing. Nothing is published until you merge that release PR.

<details><summary>CHANGELOG.md as the first release PR would write it</summary>

```markdown
## [Unreleased]

## [0.0.2] - <date>

### Fixed

- address codebase review findings

### Other

- bold
- transpose
- bump deps
- update man page
- add piping example to readme
- simplify examples
- add comparison char

### Details

- Copied text now survives `cb` exiting on Linux. …
- … (the rest of #15's notes)

## [0.0.1] - 2022-02-21

- Initial release.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan