### PR TITLE
Upgrade all dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install rust toolchain (v${{ env.MIN_SUPPORTED_RUST_VERSION }})
         uses: dtolnay/rust-toolchain@master
@@ -65,7 +65,7 @@ jobs:
           - { os: windows-11-arm, target: aarch64-pc-windows-msvc }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract crate information
         shell: bash
@@ -266,13 +266,13 @@ jobs:
           fakeroot dpkg-deb --build "${DPKG_DIR}" "${DPKG_PATH}"
 
       - name: "Artifact upload: tarball"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.package.outputs.PKG_NAME }}
           path: ${{ steps.package.outputs.PKG_PATH }}
 
       - name: "Artifact upload: Debian package"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.debian-package.outputs.DPKG_NAME
         with:
           name: ${{ steps.debian-package.outputs.DPKG_NAME }}
@@ -286,7 +286,7 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: steps.is-release.outputs.IS_RELEASE
         with:
           files: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -66,7 +66,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clipboard-cli"
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "equivalent"
@@ -172,18 +172,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nom"
@@ -319,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "proc-macro2"
@@ -386,9 +383,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "syn"
@@ -434,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wayland-backend"


### PR DESCRIPTION
Upgrades every Cargo dependency and GitHub Action to its latest version.

## Cargo

`arboard`, the only direct dependency, is already on its newest release (3.6.1). `cargo update` brought the lockfile's transitive crates current:

| Crate | From | To |
| --- | --- | --- |
| `cfg-if` | 1.0.0 | 1.0.4 |
| `downcast-rs` | 1.2.0 | 1.2.1 |
| `log` | 0.4.17 | 0.4.34 |
| `memchr` | 2.5.0 | 2.8.3 |
| `pkg-config` | 0.3.26 | 0.3.34 |
| `smallvec` | 1.10.0 | 1.16.0 |
| `unicode-ident` | 1.0.6 | 1.0.24 |

**The MSRV stays at 1.86.** I scanned every crate in the lockfile, for all platforms (70 of 70), and the highest `rust-version` is still `wayland-protocols` at 1.86.

## GitHub Actions

| Action | From | To | Breaking changes that matter here |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v7 | None. v6 stores persisted credentials in a separate file, and no step reads them. |
| `actions/upload-artifact` | v4 | v7 | None. v7 adds an opt-in `archive: false` mode; zipped uploads are unchanged. |
| `softprops/action-gh-release` | v2 | v3 | None. It only moves to the Node 24 runtime. |

All three now run on Node 24. That clears the `Node.js 20 is deprecated` warning the jobs were printing. `rust-cache` (v2), `release-plz/action` (v0.5) and `rust-toolchain`, which tracks its branches, were already current.

This supersedes Dependabot's #11, #12 and #13. #14 (`copypasta` 0.7.1 → 0.10.2) is obsolete, because #15 removed `copypasta` entirely.

## Verification

- `cargo fmt --check`, `cargo clippy --locked --all-targets --all-features` (no warnings) and `cargo test --locked` (13/13) pass on both stable and 1.86.0.
- `actionlint` passes on both workflows.
- CI on this PR runs the bumped `checkout`, `upload-artifact` and `rust-cache` steps on all three platforms. `action-gh-release` only runs on a tag, so its first real run will be the next release.

## After merging

Merging will make release-plz open a **0.0.3 release PR**. The published package includes `Cargo.lock`, so a lockfile change counts as a new release. That release's changelog will list this PR's `deps:` commit; the `ci:` commit is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan