### PR TITLE
feat: add cb peek to search clipboard history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +42,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -47,6 +101,13 @@ name = "clipboard-cli"
 version = "0.0.2"
 dependencies = [
  "arboard",
+ "crossterm",
+ "dirs",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "syntect",
+ "two-face",
 ]
 
 [[package]]
@@ -56,6 +117,152 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -69,10 +276,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -97,6 +319,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +342,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "gethostname"
@@ -125,12 +381,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -138,6 +416,18 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -150,16 +440,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -177,10 +539,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nom"
@@ -189,6 +582,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -265,6 +673,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +741,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,12 +780,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -370,10 +902,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "shlex"
@@ -382,10 +984,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -396,6 +1079,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -415,8 +1116,29 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "tree_magic_mini"
@@ -430,10 +1152,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "two-face"
+version = "0.5.2+bat-0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915be7adc2ff6f4338acbf71f3eda0a146f46003b992a1669c674308610efdac"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wayland-backend"
@@ -504,6 +1276,37 @@ checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -628,3 +1431,15 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,11 @@ path = "src/main.rs"
 
 [dependencies]
 arboard = { version = "3.6", default-features = false, features = ["wayland-data-control"] }
+crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
+dirs = "6.0"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29", "layout-cache"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+syntect = { version = "5.3", default-features = false, features = ["parsing", "regex-fancy"] }
+# bat's syntaxes and themes, so previews look the way they do in `bat`.
+two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }

--- a/README.md
+++ b/README.md
@@ -26,19 +26,48 @@ cb | vim -
 # Search clipboard contents
 cb | grep hello
 
+# Search clipboard history, preview it, and copy an entry again
+cb peek
+
 # Show all options
 cb --help
 ```
 
+## History
+
+`cb` remembers what it copies, and what it finds on the clipboard when it
+prints it, so copies made in other programs show up too. `cb peek` opens that
+history: newest first on the left, and on the right a preview of the selected
+entry, syntax highlighted with [bat](https://github.com/sharkdp/bat)'s syntaxes
+and themes.
+
+| Key                         | Action                                     |
+| --------------------------- | ------------------------------------------ |
+| Type                        | Search every line of every entry           |
+| `↑` `↓`                     | Move through the entries                   |
+| `Ctrl-R` `Ctrl-S`           | Step to the next older or newer match      |
+| `PgUp` `PgDn`, `Shift-↑` `Shift-↓` | Scroll the preview                  |
+| `Backspace` `Ctrl-W` `Ctrl-U` | Delete a character, a word, or the search |
+| `Enter`                     | Copy the selected entry and exit           |
+| `Esc`, `Ctrl-C`             | Exit without copying                       |
+
+The search is case-sensitive only if it contains an uppercase letter.
+
+History holds the last 500 copies, up to 1 MiB each, in a file only you can
+read: `~/.local/share/cb/history.jsonl` on Linux,
+`~/Library/Application Support/cb/history.jsonl` on macOS, and
+`%APPDATA%\cb\history.jsonl` on Windows. Set `CB_HISTORY_FILE` to keep it
+somewhere else, or to an empty string to turn history off. The preview theme
+comes from `CB_THEME`, or else `BAT_THEME`.
+
 ## Upcoming
 
 ```bash
-# List clipboard history
+# Print history without the picker
 cb list
 
-# View previous clipboard
+# Print a previous clipboard entry
 cb peek 1
-cb p 1
 ```
 
 ## Releasing
@@ -60,4 +89,4 @@ changelog.
 | Single Command | ✅            | ❌              | ✅              | ✅                |
 | Cross Platform | ✅            | ❌ (macOS only) | ❌ (linux only) | ❌ (windows only) |
 | Simple API     | ✅            | ✅              | ❌              | ✅                |
-| History Peek   | 🚧 planned    | ❌              | ❌              | ❌                |
+| History Peek   | ✅            | ❌              | ❌              | ❌                |

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -6,6 +6,8 @@ cb \- a better command line clipboard
 .SH SYNOPSIS
 .PP
 \f[B]cb\f[R] [\f[I]FILE\f[R]]
+.br
+\f[B]cb peek\f[R]
 .SH DESCRIPTION
 .PP
 Copy \f[I]FILE\f[R], or whatever is piped in, to the system clipboard.
@@ -17,6 +19,45 @@ printing, so copying a file and printing the clipboard reproduces it.
 On Linux, X11 and Wayland clipboards only live as long as the program
 that set them, so \f[B]cb\f[R] leaves a background process serving the
 copied text until another program copies something.
+.PP
+\f[B]cb\f[R] keeps a history of what it copies, and of what it finds on
+the clipboard when printing it, so copies made in other programs are
+included too.
+It holds the last 500 copies of up to 1 MiB each.
+.SH COMMANDS
+.TP
+\f[B]peek\f[R]
+Search clipboard history and copy an entry again.
+Entries are listed newest first, with a preview of the selected one,
+syntax highlighted with the syntaxes and themes of \f[B]bat\f[R](1).
+The syntax is picked from the name of the file the entry was copied
+from, or failing that, from its content.
+Needs an interactive terminal.
+To copy a file named \f[I]peek\f[R], use \f[B]cb ./peek\f[R].
+.PP
+In \f[B]peek\f[R]:
+.TP
+typing
+Search every line of every entry.
+The search is case\-sensitive only if it contains an uppercase letter.
+.TP
+\f[B]Up\f[R], \f[B]Down\f[R], \f[B]Ctrl\-P\f[R], \f[B]Ctrl\-N\f[R]
+Move through the entries.
+.TP
+\f[B]Ctrl\-R\f[R], \f[B]Ctrl\-S\f[R]
+Step to the next older or newer match.
+.TP
+\f[B]PgUp\f[R], \f[B]PgDn\f[R], \f[B]Shift\-Up\f[R], \f[B]Shift\-Down\f[R]
+Scroll the preview.
+.TP
+\f[B]Backspace\f[R], \f[B]Ctrl\-W\f[R], \f[B]Ctrl\-U\f[R]
+Delete a character, a word, or the whole search.
+.TP
+\f[B]Enter\f[R]
+Copy the selected entry and exit.
+.TP
+\f[B]Esc\f[R], \f[B]Ctrl\-C\f[R], \f[B]Ctrl\-G\f[R]
+Exit without copying.
 .SH OPTIONS
 .TP
 \f[B]\-h\f[R], \f[B]\-\-help\f[R]
@@ -43,13 +84,42 @@ cb | vim \-
 \f[B]Search clipboard contents\f[R]
 .PP
 cb | grep hello
+.PP
+\f[B]Copy something from earlier\f[R]
+.PP
+cb peek
+.SH ENVIRONMENT
+.TP
+\f[B]CB_HISTORY_FILE\f[R]
+Where to keep history.
+An empty value turns history off.
+.TP
+\f[B]CB_THEME\f[R], \f[B]BAT_THEME\f[R]
+The theme for \f[B]peek\f[R] previews, such as \f[I]ansi\f[R] or
+\f[I]Monokai Extended Light\f[R].
+\f[B]CB_THEME\f[R] wins; the default is \f[I]Monokai Extended\f[R].
+.TP
+\f[B]NO_COLOR\f[R]
+If set, previews are not colored.
+.TP
+\f[B]COLORTERM\f[R]
+Unless it is \f[I]truecolor\f[R] or \f[I]24bit\f[R], previews use the
+256\-color palette.
+.SH FILES
+.TP
+\f[I]$XDG_DATA_HOME/cb/history.jsonl\f[R]
+History on Linux, by default \f[I]\[ti]/.local/share/cb/history.jsonl\f[R].
+On macOS it is in \f[I]\[ti]/Library/Application Support/cb\f[R], and on
+Windows in \f[I]%APPDATA%\[rs]cb\f[R].
+Only its owner can read it.
 .SH EXIT STATUS
 .TP
 0
 Success.
 .TP
 1
-The file could not be read or the clipboard could not be accessed.
+The file could not be read, the clipboard could not be accessed, or
+\f[B]peek\f[R] had no history or no terminal to show it in.
 .TP
 2
 Invalid arguments.

--- a/doc/cb.md
+++ b/doc/cb.md
@@ -24,3 +24,7 @@ cb | vim -
 **Search clipboard contents**
 
 cb | grep hello
+
+**Search clipboard history and copy an entry again**
+
+cb peek

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,0 +1,427 @@
+//! Syntax highlighting for `cb peek` previews, with bat's syntaxes and themes.
+
+use std::env;
+use std::iter;
+use std::path::Path;
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use serde::de::IgnoredAny;
+use syntect::highlighting::{
+    FontStyle, HighlightIterator, HighlightState, Highlighter as ThemeHighlighter, Theme,
+};
+use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
+use two_face::theme::{EmbeddedLazyThemeSet, EmbeddedThemeName};
+
+/// bat's default theme.
+const DEFAULT_THEME: EmbeddedThemeName = EmbeddedThemeName::MonokaiExtended;
+
+/// Columns between tab stops, as in bat.
+const TAB_WIDTH: usize = 4;
+
+/// Longer lines are shown without highlighting. Parsing gets slow on things
+/// like minified JSON, and the preview only has room for the start of them.
+const MAX_HIGHLIGHTED_LINE_BYTES: usize = 4096;
+
+/// Lines past this are shown without highlighting, so that scrolling deep into
+/// a large entry doesn't stall on parsing everything above it.
+const MAX_HIGHLIGHTED_LINES: usize = 10_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Colors {
+    /// `NO_COLOR` is set.
+    None,
+    /// The 256-color palette, for terminals that don't advertise true color.
+    Ansi256,
+    TrueColor,
+}
+
+pub struct Highlighter {
+    syntaxes: SyntaxSet,
+    theme: Theme,
+    colors: Colors,
+}
+
+impl Highlighter {
+    /// Takes the theme from `CB_THEME`, falling back to `BAT_THEME` and then
+    /// bat's default, and color support from `NO_COLOR` and `COLORTERM`.
+    pub fn from_env() -> Result<Self, String> {
+        let theme = match env::var("CB_THEME") {
+            Ok(name) if !name.is_empty() => {
+                find_theme(&name).ok_or_else(|| format!("unknown theme '{}' in CB_THEME", name))?
+            }
+            // BAT_THEME may name a theme of the user's own that we don't have.
+            _ => env::var("BAT_THEME")
+                .ok()
+                .and_then(|name| find_theme(&name))
+                .unwrap_or(DEFAULT_THEME),
+        };
+        let colors = if env::var_os("NO_COLOR").is_some_and(|value| !value.is_empty()) {
+            Colors::None
+        } else if cfg!(windows)
+            || matches!(env::var("COLORTERM").as_deref(), Ok("truecolor" | "24bit"))
+        {
+            // Windows consoles have handled true color since Windows 10.
+            Colors::TrueColor
+        } else {
+            Colors::Ansi256
+        };
+        Ok(Self::new(theme, colors))
+    }
+
+    pub fn new(theme: EmbeddedThemeName, colors: Colors) -> Self {
+        Self {
+            syntaxes: two_face::syntax::extra_newlines(),
+            theme: two_face::theme::extra().get(theme).clone(),
+            colors,
+        }
+    }
+
+    /// Picks a syntax from the file the text was copied from, or failing
+    /// that, from the text itself.
+    fn syntax_for(&self, text: &str, source: Option<&Path>) -> &SyntaxReference {
+        source
+            .and_then(|path| self.syntax_for_path(path))
+            .or_else(|| self.syntax_for_text(text))
+            .unwrap_or_else(|| self.syntaxes.find_syntax_plain_text())
+    }
+
+    fn syntax_for_path(&self, path: &Path) -> Option<&SyntaxReference> {
+        // Whole names first, for files like `Dockerfile` and `Makefile`.
+        let name = path.file_name()?.to_str()?;
+        self.syntaxes.find_syntax_by_extension(name).or_else(|| {
+            let extension = path.extension()?.to_str()?;
+            self.syntaxes.find_syntax_by_extension(extension)
+        })
+    }
+
+    fn syntax_for_text(&self, text: &str) -> Option<&SyntaxReference> {
+        let text = text.trim_start();
+        let first_line = text.lines().next()?;
+        if let Some(syntax) = self.syntaxes.find_syntax_by_first_line(first_line) {
+            return Some(syntax);
+        }
+        // Things often piped into cb that have no telltale first line.
+        let name = if first_line.starts_with("diff ")
+            || (first_line.starts_with("--- ") && text.contains("\n+++ "))
+        {
+            "Diff"
+        } else if (text.starts_with('{') || text.starts_with('['))
+            && serde_json::from_str::<IgnoredAny>(text).is_ok()
+        {
+            "JSON"
+        } else {
+            return None;
+        };
+        self.syntaxes.find_syntax_by_name(name)
+    }
+
+    fn style(&self, style: syntect::highlighting::Style) -> Style {
+        let mut out = Style::new();
+        if let Some(color) = convert_color(style.foreground, self.colors) {
+            out = out.fg(color);
+        }
+        for (font, modifier) in [
+            (FontStyle::BOLD, Modifier::BOLD),
+            (FontStyle::ITALIC, Modifier::ITALIC),
+            (FontStyle::UNDERLINE, Modifier::UNDERLINED),
+        ] {
+            if style.font_style.contains(font) {
+                out = out.add_modifier(modifier);
+            }
+        }
+        out
+    }
+}
+
+fn find_theme(name: &str) -> Option<EmbeddedThemeName> {
+    EmbeddedLazyThemeSet::theme_names()
+        .iter()
+        .copied()
+        .find(|theme| theme.as_name().eq_ignore_ascii_case(name))
+}
+
+/// Converts a theme color the way bat does. Its `ansi` and `base16` themes
+/// use alpha 0 to mean palette color number `r`, and alpha 1 to mean the
+/// terminal's default color. The background is always left to the terminal.
+fn convert_color(color: syntect::highlighting::Color, colors: Colors) -> Option<Color> {
+    match (color.a, colors) {
+        (_, Colors::None) | (1, _) => None,
+        (0, _) => Some(match color.r {
+            0 => Color::Black,
+            1 => Color::Red,
+            2 => Color::Green,
+            3 => Color::Yellow,
+            4 => Color::Blue,
+            5 => Color::Magenta,
+            6 => Color::Cyan,
+            7 => Color::Gray,
+            n => Color::Indexed(n),
+        }),
+        (_, Colors::TrueColor) => Some(Color::Rgb(color.r, color.g, color.b)),
+        (_, Colors::Ansi256) => Some(Color::Indexed(ansi256(color.r, color.g, color.b))),
+    }
+}
+
+/// The nearest color in xterm's 256-color palette: the gray ramp for grays,
+/// the 6×6×6 color cube for everything else.
+fn ansi256(r: u8, g: u8, b: u8) -> u8 {
+    if r == g && g == b {
+        return match r {
+            0..8 => 16,
+            249.. => 231,
+            _ => 232 + ((r - 8) / 10).min(23),
+        };
+    }
+    let level = |v: u8| match v {
+        0..48 => 0,
+        48..115 => 1,
+        _ => (v - 35) / 40,
+    };
+    16 + 36 * level(r) + 6 * level(g) + level(b)
+}
+
+/// Appends `text` to `spans` as it should appear on screen: tabs expand to the
+/// next tab stop, line endings are dropped, and other control characters
+/// become `�`, so clipboard contents can't send escape sequences to the
+/// terminal. `column` tracks the position within the line across calls.
+pub fn push_span(spans: &mut Vec<Span<'static>>, column: &mut usize, text: &str, style: Style) {
+    let mut shown = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\t' => {
+                let width = TAB_WIDTH - *column % TAB_WIDTH;
+                shown.extend(iter::repeat_n(' ', width));
+                *column += width;
+            }
+            '\n' | '\r' => {}
+            c => {
+                shown.push(if c.is_control() {
+                    char::REPLACEMENT_CHARACTER
+                } else {
+                    c
+                });
+                *column += 1;
+            }
+        }
+    }
+    if !shown.is_empty() {
+        spans.push(Span::styled(shown, style));
+    }
+}
+
+/// One entry's highlighted lines, produced as they're scrolled into view.
+pub struct Preview {
+    text: String,
+    /// Byte offset of the first line not highlighted yet.
+    next: usize,
+    parse: ParseState,
+    highlight: HighlightState,
+    /// Set if the parser gives up, after which lines are shown plain.
+    failed: bool,
+    lines: Vec<Line<'static>>,
+    pub syntax: String,
+    pub line_count: usize,
+}
+
+impl Preview {
+    pub fn new(highlighter: &Highlighter, text: &str, source: Option<&Path>) -> Self {
+        let syntax = highlighter.syntax_for(text, source);
+        let theme = ThemeHighlighter::new(&highlighter.theme);
+        Self {
+            text: text.to_owned(),
+            next: 0,
+            parse: ParseState::new(syntax),
+            highlight: HighlightState::new(&theme, ScopeStack::new()),
+            failed: false,
+            lines: Vec::new(),
+            syntax: syntax.name.clone(),
+            line_count: text.lines().count().max(1),
+        }
+    }
+
+    /// The first `count` lines, or all of them if there are fewer.
+    pub fn lines(&mut self, highlighter: &Highlighter, count: usize) -> &[Line<'static>] {
+        let theme = ThemeHighlighter::new(&highlighter.theme);
+        while self.lines.len() < count && self.next < self.text.len() {
+            let rest = &self.text[self.next..];
+            let line = &rest[..rest.find('\n').map_or(rest.len(), |end| end + 1)];
+            self.next += line.len();
+
+            let plain = self.failed
+                || highlighter.colors == Colors::None
+                || line.len() > MAX_HIGHLIGHTED_LINE_BYTES
+                || self.lines.len() >= MAX_HIGHLIGHTED_LINES;
+            let ops = if plain {
+                None
+            } else {
+                match self.parse.parse_line(line, &highlighter.syntaxes) {
+                    Ok(ops) => Some(ops),
+                    Err(_) => {
+                        self.failed = true;
+                        None
+                    }
+                }
+            };
+
+            let mut spans = Vec::new();
+            let mut column = 0;
+            match ops {
+                Some(ops) => {
+                    for (style, piece) in
+                        HighlightIterator::new(&mut self.highlight, &ops, line, &theme)
+                    {
+                        push_span(&mut spans, &mut column, piece, highlighter.style(style));
+                    }
+                }
+                None => push_span(&mut spans, &mut column, line, Style::new()),
+            }
+            self.lines.push(Line::from(spans));
+        }
+        &self.lines[..count.min(self.lines.len())]
+    }
+}
+
+/// Loading bat's syntaxes takes a moment, so tests share one highlighter.
+#[cfg(test)]
+pub fn test_highlighter() -> &'static Highlighter {
+    static HIGHLIGHTER: std::sync::OnceLock<Highlighter> = std::sync::OnceLock::new();
+    HIGHLIGHTER.get_or_init(|| Highlighter::new(DEFAULT_THEME, Colors::TrueColor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn syntax(text: &str, source: Option<&str>) -> String {
+        test_highlighter()
+            .syntax_for(text, source.map(Path::new))
+            .name
+            .clone()
+    }
+
+    fn shown(pieces: &[&str]) -> String {
+        let mut spans = Vec::new();
+        let mut column = 0;
+        for piece in pieces {
+            push_span(&mut spans, &mut column, piece, Style::new());
+        }
+        spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn syntax_comes_from_the_source_file() {
+        for (path, expected) in [
+            ("src/main.rs", "Rust"),
+            ("Cargo.toml", "TOML"),
+            ("Dockerfile", "Dockerfile"),
+            ("notes.txt", "Plain Text"),
+        ] {
+            assert_eq!(syntax("", Some(path)), expected, "{}", path);
+        }
+    }
+
+    #[test]
+    fn syntax_is_guessed_from_the_text() {
+        for (text, expected) in [
+            ("#!/bin/bash\necho hi", "Bourne Again Shell (bash)"),
+            ("<?xml version=\"1.0\"?>\n<a/>", "XML"),
+            ("diff --git a/x b/x\n--- a/x\n+++ b/x", "Diff"),
+            ("  {\"a\": [1, 2]}\n", "JSON"),
+            ("{ not json", "Plain Text"),
+            ("just some words", "Plain Text"),
+        ] {
+            assert_eq!(syntax(text, None), expected, "{}", text);
+        }
+    }
+
+    #[test]
+    fn the_source_file_wins_over_the_text() {
+        assert_eq!(syntax("{\"a\": 1}", Some("x.rs")), "Rust");
+    }
+
+    #[test]
+    fn previews_are_highlighted_lazily() {
+        let text: String = (0..100).map(|i| format!("let x{} = {};\n", i, i)).collect();
+        let mut preview = Preview::new(test_highlighter(), &text, Some(Path::new("a.rs")));
+        assert_eq!(preview.line_count, 100);
+        assert_eq!(preview.lines(test_highlighter(), 5).len(), 5);
+        assert_eq!(preview.lines.len(), 5);
+        assert_eq!(preview.lines(test_highlighter(), 500).len(), 100);
+    }
+
+    #[test]
+    fn code_gets_colors_from_the_theme() {
+        let mut preview = Preview::new(
+            test_highlighter(),
+            "fn main() {}\n",
+            Some(Path::new("a.rs")),
+        );
+        let line = &preview.lines(test_highlighter(), 1)[0];
+        assert_eq!(line.to_string(), "fn main() {}");
+        let colors: Vec<_> = line.spans.iter().filter_map(|span| span.style.fg).collect();
+        assert!(colors.len() > 1, "{:?}", line);
+        assert!(colors.iter().all(|color| matches!(color, Color::Rgb(..))));
+    }
+
+    #[test]
+    fn overlong_lines_are_shown_plain() {
+        let text = format!("[{}]", "1,".repeat(MAX_HIGHLIGHTED_LINE_BYTES));
+        let mut preview = Preview::new(test_highlighter(), &text, Some(Path::new("a.json")));
+        let line = &preview.lines(test_highlighter(), 1)[0];
+        assert_eq!(line.spans.len(), 1);
+        assert_eq!(line.spans[0].style, Style::new());
+    }
+
+    #[test]
+    fn control_characters_never_reach_the_terminal() {
+        assert_eq!(
+            shown(&["a\u{1b}[31mb\u{7}c\u{9b}\r\n"]),
+            "a\u{fffd}[31mb\u{fffd}c\u{fffd}"
+        );
+    }
+
+    #[test]
+    fn tabs_expand_to_tab_stops_across_spans() {
+        assert_eq!(shown(&["\tx"]), "    x");
+        assert_eq!(shown(&["ab", "\tc"]), "ab  c");
+    }
+
+    #[test]
+    fn palette_colors_follow_bat() {
+        let palette = |r, a| syntect::highlighting::Color { r, g: 0, b: 0, a };
+        assert_eq!(
+            convert_color(palette(1, 0), Colors::TrueColor),
+            Some(Color::Red)
+        );
+        assert_eq!(
+            convert_color(palette(7, 0), Colors::Ansi256),
+            Some(Color::Gray)
+        );
+        assert_eq!(
+            convert_color(palette(42, 0), Colors::TrueColor),
+            Some(Color::Indexed(42))
+        );
+        assert_eq!(convert_color(palette(1, 1), Colors::TrueColor), None);
+        assert_eq!(convert_color(palette(200, 255), Colors::None), None);
+    }
+
+    #[test]
+    fn rgb_maps_onto_the_256_color_palette() {
+        assert_eq!(ansi256(0, 0, 0), 16);
+        assert_eq!(ansi256(255, 255, 255), 231);
+        assert_eq!(ansi256(128, 128, 128), 244);
+        assert_eq!(ansi256(255, 0, 0), 196);
+        assert_eq!(ansi256(0, 0, 255), 21);
+    }
+
+    #[test]
+    fn themes_are_found_by_name_ignoring_case() {
+        assert_eq!(
+            find_theme("monokai extended"),
+            Some(EmbeddedThemeName::MonokaiExtended)
+        );
+        assert_eq!(find_theme("ansi"), Some(EmbeddedThemeName::Ansi));
+        assert_eq!(find_theme("no such theme"), None);
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,272 @@
+//! Clipboard history: one JSON object per line, oldest first.
+
+use std::env;
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Where to keep history instead of the platform's data directory. An empty
+/// value turns history off.
+pub const HISTORY_ENV: &str = "CB_HISTORY_FILE";
+
+/// Only the newest this many entries are kept.
+const MAX_ENTRIES: usize = 500;
+
+/// Larger copies aren't kept, so that reading history stays fast.
+const MAX_ENTRY_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entry {
+    pub text: String,
+    /// The file the text was copied from, used to pick a syntax for its preview.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<PathBuf>,
+    /// When it was copied, in seconds since the Unix epoch.
+    pub time: u64,
+}
+
+/// The history file, or `None` if history is turned off.
+pub fn path() -> Option<PathBuf> {
+    resolve_path(env::var_os(HISTORY_ENV))
+}
+
+fn resolve_path(overridden: Option<OsString>) -> Option<PathBuf> {
+    match overridden {
+        Some(path) if path.is_empty() => None,
+        Some(path) => Some(PathBuf::from(path)),
+        None => dirs::data_dir().map(|dir| dir.join("cb").join("history.jsonl")),
+    }
+}
+
+pub fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+/// Adds `text` to history as the newest entry, unless history is turned off.
+pub fn record(text: &str, source: Option<&Path>) -> Result<(), String> {
+    let Some(path) = path() else {
+        return Ok(());
+    };
+    let entry = Entry {
+        text: text.to_owned(),
+        source: source.map(|source| fs::canonicalize(source).unwrap_or_else(|_| source.to_owned())),
+        time: now(),
+    };
+    let context = |e: io::Error| format!("{}: {}", path.display(), e);
+    let mut entries = load(&path).map_err(context)?;
+    if push(&mut entries, entry) {
+        save(&path, &entries).map_err(context)
+    } else {
+        Ok(())
+    }
+}
+
+/// Reads history, oldest first. A missing file is an empty history, and lines
+/// that don't parse, say from a write that was cut short, are skipped.
+pub fn load(path: &Path) -> io::Result<Vec<Entry>> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut entries = Vec::new();
+    for line in BufReader::new(file).lines() {
+        if let Ok(entry) = serde_json::from_str(&line?) {
+            entries.push(entry);
+        }
+    }
+    Ok(entries)
+}
+
+/// Adds `entry` as the newest, replacing any earlier copy of the same text and
+/// dropping the oldest entries past the limit. Returns whether anything changed:
+/// empty and oversized text isn't kept, and text that is already the newest
+/// entry is left alone.
+fn push(entries: &mut Vec<Entry>, mut entry: Entry) -> bool {
+    if entry.text.is_empty() || entry.text.len() > MAX_ENTRY_BYTES {
+        return false;
+    }
+    if entries.last().is_some_and(|last| {
+        last.text == entry.text && (entry.source.is_none() || entry.source == last.source)
+    }) {
+        return false;
+    }
+    if let Some(index) = entries.iter().rposition(|old| old.text == entry.text) {
+        // Printing the clipboard records it without a source; keep the file
+        // it originally came from so the preview still knows its syntax.
+        let old = entries.remove(index);
+        entry.source = entry.source.or(old.source);
+    }
+    entries.push(entry);
+    if entries.len() > MAX_ENTRIES {
+        entries.drain(..entries.len() - MAX_ENTRIES);
+    }
+    true
+}
+
+/// Replaces the history file in one step, so a reader never sees half of it.
+fn save(path: &Path, entries: &[Entry]) -> io::Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let temp = path.with_extension(format!("{}.tmp", std::process::id()));
+    let saved = write_entries(&temp, entries).and_then(|()| fs::rename(&temp, path));
+    if saved.is_err() {
+        fs::remove_file(&temp).ok();
+    }
+    saved
+}
+
+fn write_entries(path: &Path, entries: &[Entry]) -> io::Result<()> {
+    let mut out = BufWriter::new(create_private(path)?);
+    for entry in entries {
+        serde_json::to_writer(&mut out, entry)?;
+        out.write_all(b"\n")?;
+    }
+    out.flush()
+}
+
+/// History can hold passwords and tokens, so only its owner may read it.
+fn create_private(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(text: &str, time: u64) -> Entry {
+        Entry {
+            text: text.to_owned(),
+            source: None,
+            time,
+        }
+    }
+
+    fn texts(entries: &[Entry]) -> Vec<&str> {
+        entries.iter().map(|entry| entry.text.as_str()).collect()
+    }
+
+    /// A path in the temp directory that no other test uses.
+    fn temp_path(name: &str) -> PathBuf {
+        env::temp_dir().join(format!("cb-test-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn push_adds_the_newest_entry_last() {
+        let mut entries = vec![entry("a", 1)];
+        assert!(push(&mut entries, entry("b", 2)));
+        assert_eq!(texts(&entries), ["a", "b"]);
+    }
+
+    #[test]
+    fn push_moves_a_repeated_copy_to_the_end() {
+        let mut entries = vec![entry("a", 1), entry("b", 2)];
+        assert!(push(&mut entries, entry("a", 3)));
+        assert_eq!(texts(&entries), ["b", "a"]);
+        assert_eq!(entries[1].time, 3);
+    }
+
+    #[test]
+    fn push_keeps_the_source_of_an_earlier_copy() {
+        let mut entries = vec![
+            Entry {
+                source: Some("main.rs".into()),
+                ..entry("fn main() {}", 1)
+            },
+            entry("b", 2),
+        ];
+        assert!(push(&mut entries, entry("fn main() {}", 3)));
+        assert_eq!(entries[1].source, Some("main.rs".into()));
+    }
+
+    #[test]
+    fn push_ignores_empty_oversized_and_unchanged_text() {
+        let mut entries = vec![entry("a", 1)];
+        assert!(!push(&mut entries, entry("", 2)));
+        assert!(!push(
+            &mut entries,
+            entry(&"x".repeat(MAX_ENTRY_BYTES + 1), 2)
+        ));
+        assert!(!push(&mut entries, entry("a", 2)));
+        assert_eq!(entries, [entry("a", 1)]);
+    }
+
+    #[test]
+    fn push_drops_the_oldest_entries_past_the_limit() {
+        let mut entries = (0..MAX_ENTRIES as u64)
+            .map(|i| entry(&i.to_string(), i))
+            .collect();
+        assert!(push(&mut entries, entry("new", 1000)));
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert_eq!(entries[0].text, "1");
+        assert_eq!(entries[MAX_ENTRIES - 1].text, "new");
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = temp_path("round-trip");
+        let path = dir.join("nested").join("history.jsonl");
+        let entries = vec![
+            Entry {
+                source: Some("/tmp/a.rs".into()),
+                ..entry("line one\n\t\"quoted\"\nline three", 1)
+            },
+            entry("second", 2),
+        ];
+        save(&path, &entries).unwrap();
+        assert_eq!(load(&path).unwrap(), entries);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn load_skips_lines_it_cannot_read() {
+        let path = temp_path("corrupt.jsonl");
+        fs::write(
+            &path,
+            "{\"text\":\"good\",\"time\":1}\n{\"text\":\"cut sh\n\n",
+        )
+        .unwrap();
+        assert_eq!(load(&path).unwrap(), [entry("good", 1)]);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn a_missing_file_is_an_empty_history() {
+        assert_eq!(load(&temp_path("missing.jsonl")).unwrap(), []);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn only_the_owner_can_read_history() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("private.jsonl");
+        save(&path, &[entry("secret", 1)]).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn an_empty_override_turns_history_off() {
+        assert_eq!(resolve_path(Some("".into())), None);
+        assert_eq!(
+            resolve_path(Some("h.jsonl".into())),
+            Some(PathBuf::from("h.jsonl"))
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,21 +2,32 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, IsTerminal, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use arboard::Clipboard;
 
+use crate::highlight::Highlighter;
+
+mod highlight;
+mod history;
+mod peek;
+
 const USAGE: &str = "\
 Usage: cb [FILE]
+       cb peek
 
 Copy FILE, or whatever is piped in, to the system clipboard.
 With no FILE and nothing piped in, print the clipboard.
+
+Commands:
+  peek               Search clipboard history and copy an entry again
 
 Examples:
   cb package.json    Copy a file
   git diff | cb      Copy piped input
   cb | grep hello    Search the clipboard
+  cb peek            Browse what you copied before
 
 Options:
   -h, --help         Print help
@@ -37,12 +48,14 @@ enum Action {
     Print,
     CopyFile(PathBuf),
     CopyStdin,
+    Peek,
 }
 
 /// Decides what to do from the arguments (excluding the program name).
 ///
 /// An explicit file always wins over stdin, so `cb notes.txt` behaves the same
 /// in a script or IDE task, where stdin is not a terminal, as it does at a prompt.
+/// `peek` is a command, so a file by that name is copied with `cb ./peek`.
 fn parse_args<I>(args: I, stdin_is_terminal: bool) -> Result<Action, String>
 where
     I: IntoIterator<Item = OsString>,
@@ -61,6 +74,7 @@ where
     match arg.to_str() {
         Some("-h" | "--help") => Ok(Action::Help),
         Some("-V" | "--version") => Ok(Action::Version),
+        Some("peek") => Ok(Action::Peek),
         Some(flag) if flag.len() > 1 && flag.starts_with('-') => {
             Err(format!("unknown option '{}'", flag))
         }
@@ -93,22 +107,64 @@ fn run(action: Action) -> Result<(), String> {
         Action::CopyFile(path) => {
             let text =
                 fs::read_to_string(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
-            copy(strip_trailing_newline(&text))
+            let text = strip_trailing_newline(&text);
+            copy(text)?;
+            remember(text, Some(&path));
+            Ok(())
         }
         Action::CopyStdin => {
             let mut text = String::new();
             io::stdin()
                 .read_to_string(&mut text)
                 .map_err(|e| format!("stdin: {}", e))?;
-            copy(strip_trailing_newline(&text))
+            let text = strip_trailing_newline(&text);
+            copy(text)?;
+            remember(text, None);
+            Ok(())
         }
+        Action::Peek => peek(),
     }
+}
+
+/// Adds text to history. Failing to is worth a warning, not a failed copy.
+fn remember(text: &str, source: Option<&Path>) {
+    if let Err(message) = history::record(text, source) {
+        eprintln!("cb: warning: could not save history: {}", message);
+    }
+}
+
+fn peek() -> Result<(), String> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err("peek needs an interactive terminal".to_owned());
+    }
+    let path = history::path().ok_or(format!(
+        "clipboard history is turned off because {} is empty",
+        history::HISTORY_ENV
+    ))?;
+    // Catch up on whatever was copied outside of cb since it last ran. There
+    // may be no clipboard to read, as over SSH, and history works without one.
+    if let Ok(text) = Clipboard::new().and_then(|mut clipboard| clipboard.get_text()) {
+        remember(&text, None);
+    }
+    let entries = history::load(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
+    if entries.is_empty() {
+        return Err("clipboard history is empty; copy something with cb first".to_owned());
+    }
+    let highlighter = Highlighter::from_env()?;
+    let Some(entry) = peek::run(entries, &highlighter).map_err(|e| e.to_string())? else {
+        return Ok(());
+    };
+    copy(&entry.text)?;
+    remember(&entry.text, entry.source.as_deref());
+    Ok(())
 }
 
 fn print() -> Result<(), String> {
     let text = Clipboard::new()
         .and_then(|mut clipboard| clipboard.get_text())
         .map_err(|e| e.to_string())?;
+    // Printing is how copies made outside of cb find their way into history.
+    remember(&text, None);
     let mut stdout = io::stdout().lock();
     match writeln!(stdout, "{}", text).and_then(|()| stdout.flush()) {
         // The reader went away early, as with `cb | head -1`; that's not an error.
@@ -272,6 +328,16 @@ mod tests {
         for flag in ["-V", "--version"] {
             assert_eq!(parse(&[flag], true), Ok(Action::Version));
         }
+    }
+
+    #[test]
+    fn peek_is_a_command() {
+        assert_eq!(parse(&["peek"], true), Ok(Action::Peek));
+        assert_eq!(parse(&["peek"], false), Ok(Action::Peek));
+        assert_eq!(
+            parse(&["./peek"], true),
+            Ok(Action::CopyFile(PathBuf::from("./peek")))
+        );
     }
 
     #[test]

--- a/src/peek.rs
+++ b/src/peek.rs
@@ -1,0 +1,626 @@
+//! `cb peek`: search clipboard history, with a syntax-highlighted preview.
+
+use std::io;
+use std::ops::Range;
+use std::path::Path;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, List, ListItem, ListState, Paragraph};
+use ratatui::{DefaultTerminal, Frame};
+
+use crate::highlight::{push_span, Highlighter, Preview};
+use crate::history::{self, Entry};
+
+/// Lines kept above a search match when the preview scrolls to it.
+const MATCH_CONTEXT: usize = 3;
+
+/// Narrower than this, the list goes above the preview instead of beside it.
+const SIDE_BY_SIDE_WIDTH: u16 = 80;
+
+const FAINT: Style = Style::new().fg(Color::DarkGray);
+const MATCH: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+const PROMPT: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+
+/// Lets the user pick an entry from `entries`, given oldest first. Returns
+/// `None` if they quit without picking one.
+pub fn run(entries: Vec<Entry>, highlighter: &Highlighter) -> io::Result<Option<Entry>> {
+    let mut app = App::new(entries, highlighter, history::now());
+    let mut terminal = match ratatui::try_init() {
+        Ok(terminal) => terminal,
+        Err(e) => {
+            ratatui::restore();
+            return Err(e);
+        }
+    };
+    let picked = app.event_loop(&mut terminal);
+    ratatui::restore();
+    Ok(picked?.map(|index| app.entries.swap_remove(index)))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Match {
+    entry: usize,
+    /// The line to show in the list: the first one that matches the search,
+    /// or with no search, the first one that isn't blank.
+    line: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    Continue,
+    Quit,
+    Copy(usize),
+}
+
+struct App<'a> {
+    /// Newest first.
+    entries: Vec<Entry>,
+    /// Lowercased copies of `entries`, for case-insensitive search.
+    lowercase: Vec<String>,
+    query: String,
+    matches: Vec<Match>,
+    list: ListState,
+    /// The first preview line on screen.
+    scroll: usize,
+    /// Lines of preview on screen at the last draw, for paging.
+    preview_height: usize,
+    /// The preview of the selected entry, kept while it stays selected.
+    preview: Option<(usize, Preview)>,
+    highlighter: &'a Highlighter,
+    now: u64,
+}
+
+impl<'a> App<'a> {
+    fn new(mut entries: Vec<Entry>, highlighter: &'a Highlighter, now: u64) -> Self {
+        entries.reverse();
+        let lowercase = entries
+            .iter()
+            .map(|entry| entry.text.to_lowercase())
+            .collect();
+        let mut app = Self {
+            entries,
+            lowercase,
+            query: String::new(),
+            matches: Vec::new(),
+            list: ListState::default(),
+            scroll: 0,
+            preview_height: 0,
+            preview: None,
+            highlighter,
+            now,
+        };
+        app.filter();
+        app
+    }
+
+    fn event_loop(&mut self, terminal: &mut DefaultTerminal) -> io::Result<Option<usize>> {
+        loop {
+            terminal.draw(|frame| self.render(frame))?;
+            // Anything else, like a resize, only needs the redraw.
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            if key.kind == KeyEventKind::Release {
+                continue;
+            }
+            match self.on_key(key) {
+                Outcome::Continue => {}
+                Outcome::Quit => return Ok(None),
+                Outcome::Copy(index) => return Ok(Some(index)),
+            }
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> Outcome {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let page = self.preview_height.max(1) as isize;
+        match key.code {
+            KeyCode::Esc => return Outcome::Quit,
+            KeyCode::Char('c' | 'g') if ctrl => return Outcome::Quit,
+            KeyCode::Enter => {
+                if let Some(selected) = self.selected() {
+                    return Outcome::Copy(selected.entry);
+                }
+            }
+            KeyCode::Up if shift => self.scroll_by(-1),
+            KeyCode::Down if shift => self.scroll_by(1),
+            KeyCode::Up => self.move_by(-1),
+            KeyCode::Down => self.move_by(1),
+            // As in a shell, Ctrl-R searches further back and Ctrl-S comes
+            // forward again.
+            KeyCode::Char('r' | 'n') if ctrl => self.move_by(1),
+            KeyCode::Char('s' | 'p') if ctrl => self.move_by(-1),
+            KeyCode::PageUp => self.scroll_by(-page),
+            KeyCode::PageDown => self.scroll_by(page),
+            KeyCode::Backspace => {
+                if self.query.pop().is_some() {
+                    self.filter();
+                }
+            }
+            KeyCode::Char('u') if ctrl => {
+                self.query.clear();
+                self.filter();
+            }
+            KeyCode::Char('w') if ctrl => {
+                let kept = self
+                    .query
+                    .trim_end()
+                    .trim_end_matches(|c: char| !c.is_whitespace())
+                    .len();
+                self.query.truncate(kept);
+                self.filter();
+            }
+            // AltGr arrives as Ctrl+Alt on Windows.
+            KeyCode::Char(c) if !ctrl || key.modifiers.contains(KeyModifiers::ALT) => {
+                self.query.push(c);
+                self.filter();
+            }
+            _ => {}
+        }
+        Outcome::Continue
+    }
+
+    /// Smart case, as in ripgrep and fzf: an uppercase letter in the search
+    /// makes it case-sensitive.
+    fn case_sensitive(&self) -> bool {
+        self.query.chars().any(char::is_uppercase)
+    }
+
+    /// Finds the entries that match the search, newest first, and selects the
+    /// newest.
+    fn filter(&mut self) {
+        let case_sensitive = self.case_sensitive();
+        let query = if case_sensitive {
+            self.query.clone()
+        } else {
+            self.query.to_lowercase()
+        };
+        self.matches = (self.entries.iter().zip(&self.lowercase))
+            .enumerate()
+            .filter_map(|(entry, (original, lowercase))| {
+                let line = if query.is_empty() {
+                    first_nonblank_line(&original.text)
+                } else {
+                    // Lowercasing never adds or removes a newline, so line
+                    // numbers in the lowercase copy hold for the original.
+                    let text = if case_sensitive {
+                        &original.text
+                    } else {
+                        lowercase
+                    };
+                    let at = text.find(&query)?;
+                    text[..at].matches('\n').count()
+                };
+                Some(Match { entry, line })
+            })
+            .collect();
+        self.select(0);
+    }
+
+    fn selected(&self) -> Option<&Match> {
+        self.list
+            .selected()
+            .and_then(|index| self.matches.get(index))
+    }
+
+    fn select(&mut self, index: usize) {
+        let Some(last) = self.matches.len().checked_sub(1) else {
+            self.list.select(None);
+            return;
+        };
+        let index = index.min(last);
+        self.list.select(Some(index));
+        // Show where the search matched, with a little context above it.
+        self.scroll = if self.query.is_empty() {
+            0
+        } else {
+            self.matches[index].line.saturating_sub(MATCH_CONTEXT)
+        };
+    }
+
+    fn move_by(&mut self, delta: isize) {
+        if let Some(index) = self.list.selected() {
+            self.select(index.saturating_add_signed(delta));
+        }
+    }
+
+    fn scroll_by(&mut self, delta: isize) {
+        let line_count = self
+            .preview
+            .as_ref()
+            .map_or(0, |(_, preview)| preview.line_count);
+        let max = line_count.saturating_sub(self.preview_height);
+        self.scroll = self.scroll.saturating_add_signed(delta).min(max);
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let [main, prompt] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(frame.area());
+        let panes = [Constraint::Percentage(40), Constraint::Percentage(60)];
+        let [list, preview] = if main.width >= SIDE_BY_SIDE_WIDTH {
+            Layout::horizontal(panes).areas(main)
+        } else {
+            Layout::vertical(panes).areas(main)
+        };
+        self.render_list(frame, list);
+        self.render_preview(frame, preview);
+        self.render_prompt(frame, prompt);
+    }
+
+    fn render_list(&mut self, frame: &mut Frame, area: Rect) {
+        let items: Vec<_> = self.matches.iter().map(|m| self.row(m)).collect();
+        let count = format!(" {}/{} ", self.matches.len(), self.entries.len());
+        let block = Block::bordered()
+            .border_style(FAINT)
+            .title_top(" History ")
+            .title_top(Line::from(count).right_aligned());
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(Style::new().add_modifier(Modifier::REVERSED));
+        frame.render_stateful_widget(list, area, &mut self.list);
+    }
+
+    /// An entry in the list: its age, then the line that matched the search
+    /// with the match picked out.
+    fn row(&self, m: &Match) -> ListItem<'static> {
+        let entry = &self.entries[m.entry];
+        let line = entry.text.lines().nth(m.line).unwrap_or_default().trim();
+        let mut spans = vec![Span::styled(
+            format!("{:>4} ", age(self.now, entry.time)),
+            FAINT,
+        )];
+        let mut column = 0;
+        if line.is_empty() {
+            spans.push(Span::styled("(blank)", FAINT));
+        } else if let Some(found) = find(line, &self.query, self.case_sensitive()) {
+            push_span(&mut spans, &mut column, &line[..found.start], Style::new());
+            push_span(&mut spans, &mut column, &line[found.clone()], MATCH);
+            push_span(&mut spans, &mut column, &line[found.end..], Style::new());
+        } else {
+            push_span(&mut spans, &mut column, line, Style::new());
+        }
+        ListItem::new(Line::from(spans))
+    }
+
+    fn render_preview(&mut self, frame: &mut Frame, area: Rect) {
+        let block = Block::bordered().border_style(FAINT);
+        let height = block.inner(area).height as usize;
+        self.preview_height = height;
+        let Some(&selected) = self.selected() else {
+            let empty = Paragraph::new(Line::styled("No matches", FAINT));
+            frame.render_widget(empty.block(block), area);
+            return;
+        };
+
+        let entry = &self.entries[selected.entry];
+        if self
+            .preview
+            .as_ref()
+            .is_none_or(|(shown, _)| *shown != selected.entry)
+        {
+            let preview = Preview::new(self.highlighter, &entry.text, entry.source.as_deref());
+            self.preview = Some((selected.entry, preview));
+        }
+        let (_, preview) = self.preview.as_mut().expect("the preview was just made");
+
+        let mut title = Vec::new();
+        if let Some(name) = entry.source.as_deref().and_then(Path::file_name) {
+            title.push(name.to_string_lossy().into_owned());
+        }
+        title.push(preview.syntax.clone());
+        title.push(match preview.line_count {
+            1 => "1 line".to_owned(),
+            n => format!("{} lines", n),
+        });
+        let mut title_spans = Vec::new();
+        push_span(
+            &mut title_spans,
+            &mut 0,
+            &format!(" {} ", title.join(" · ")),
+            Style::new(),
+        );
+
+        self.scroll = self.scroll.min(preview.line_count.saturating_sub(height));
+        let number_width = preview.line_count.to_string().len();
+        let searching = !self.query.is_empty();
+        let lines: Vec<_> = preview
+            .lines(self.highlighter, self.scroll + height)
+            .iter()
+            .enumerate()
+            .skip(self.scroll)
+            .map(|(number, line)| {
+                let style = if searching && number == selected.line {
+                    MATCH
+                } else {
+                    FAINT
+                };
+                let gutter = format!("{:>width$} │ ", number + 1, width = number_width);
+                let mut spans = vec![Span::styled(gutter, style)];
+                spans.extend(line.spans.iter().cloned());
+                Line::from(spans)
+            })
+            .collect();
+        let block = block.title_top(Line::from(title_spans));
+        frame.render_widget(Paragraph::new(lines).block(block), area);
+    }
+
+    fn render_prompt(&self, frame: &mut Frame, area: Rect) {
+        let mut spans = vec![Span::styled("> ", PROMPT)];
+        push_span(&mut spans, &mut 0, &self.query, Style::new());
+        let prompt = Line::from(spans);
+        let cursor = prompt.width() as u16;
+        let hints =
+            Line::styled("↑↓ select  ⏎ copy  PgUp/PgDn scroll  Esc quit ", FAINT).right_aligned();
+        if prompt.width() + hints.width() < area.width as usize {
+            frame.render_widget(hints, area);
+        }
+        frame.render_widget(prompt, area);
+        frame.set_cursor_position((area.x + cursor.min(area.width.saturating_sub(1)), area.y));
+    }
+}
+
+fn first_nonblank_line(text: &str) -> usize {
+    text.lines()
+        .position(|line| !line.trim().is_empty())
+        .unwrap_or(0)
+}
+
+/// How long ago `then` was, in a few characters.
+fn age(now: u64, then: u64) -> String {
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+    const YEAR: u64 = 365 * DAY;
+    let seconds = now.saturating_sub(then);
+    match seconds {
+        0..MINUTE => "now".to_owned(),
+        MINUTE..HOUR => format!("{}m", seconds / MINUTE),
+        HOUR..DAY => format!("{}h", seconds / HOUR),
+        DAY..YEAR => format!("{}d", seconds / DAY),
+        _ => format!("{}y", seconds / YEAR),
+    }
+}
+
+/// Where `needle` first appears in `haystack`, as a byte range of `haystack`.
+/// Without `case_sensitive`, letters are compared by their lowercase forms,
+/// char by char, so the range stays right even where lowercasing changes how
+/// many bytes a char takes.
+fn find(haystack: &str, needle: &str, case_sensitive: bool) -> Option<Range<usize>> {
+    if needle.is_empty() {
+        return None;
+    }
+    if case_sensitive {
+        return haystack
+            .find(needle)
+            .map(|start| start..start + needle.len());
+    }
+    let needle: Vec<char> = needle.chars().flat_map(char::to_lowercase).collect();
+    haystack.char_indices().find_map(|(start, _)| {
+        let mut wanted = needle.iter();
+        for (offset, c) in haystack[start..].char_indices() {
+            let end = start + offset + c.len_utf8();
+            for lower in c.to_lowercase() {
+                match wanted.next() {
+                    Some(&want) if want == lower => {}
+                    Some(_) => return None,
+                    None => return Some(start..end),
+                }
+            }
+            if wanted.as_slice().is_empty() {
+                return Some(start..end);
+            }
+        }
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::highlight::test_highlighter;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    const NOW: u64 = 1_000_000;
+
+    /// An app over `texts`, given oldest first as history keeps them, copied a
+    /// minute apart.
+    fn app(texts: &[&str]) -> App<'static> {
+        let entries = texts
+            .iter()
+            .enumerate()
+            .map(|(i, text)| Entry {
+                text: (*text).to_owned(),
+                source: None,
+                time: NOW - 60 * (texts.len() - i) as u64,
+            })
+            .collect();
+        App::new(entries, test_highlighter(), NOW)
+    }
+
+    fn press(app: &mut App, code: KeyCode) -> Outcome {
+        app.on_key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn ctrl(app: &mut App, c: char) -> Outcome {
+        app.on_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
+    }
+
+    fn type_text(app: &mut App, text: &str) {
+        for c in text.chars() {
+            assert_eq!(press(app, KeyCode::Char(c)), Outcome::Continue);
+        }
+    }
+
+    fn matched<'a>(app: &'a App) -> Vec<&'a str> {
+        (app.matches.iter())
+            .map(|m| app.entries[m.entry].text.as_str())
+            .collect()
+    }
+
+    fn selected<'a>(app: &'a App) -> &'a str {
+        &app.entries[app.selected().expect("something is selected").entry].text
+    }
+
+    fn render(app: &mut App, width: u16, height: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|y| (0..width).map(|x| buffer[(x, y)].symbol()).collect())
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn newest_entry_comes_first_and_is_selected() {
+        let app = app(&["old", "new"]);
+        assert_eq!(matched(&app), ["new", "old"]);
+        assert_eq!(selected(&app), "new");
+    }
+
+    #[test]
+    fn arrows_move_the_selection_and_stop_at_the_ends() {
+        let mut app = app(&["old", "new"]);
+        press(&mut app, KeyCode::Up);
+        assert_eq!(selected(&app), "new");
+        press(&mut app, KeyCode::Down);
+        assert_eq!(selected(&app), "old");
+        press(&mut app, KeyCode::Down);
+        assert_eq!(selected(&app), "old");
+    }
+
+    #[test]
+    fn typing_filters_with_smart_case() {
+        let mut app = app(&["Hello world", "hello there", "bye"]);
+        type_text(&mut app, "hello");
+        assert_eq!(matched(&app), ["hello there", "Hello world"]);
+        ctrl(&mut app, 'u');
+        type_text(&mut app, "Hello");
+        assert_eq!(matched(&app), ["Hello world"]);
+    }
+
+    #[test]
+    fn ctrl_r_steps_back_through_matches() {
+        let mut app = app(&["git push", "ls", "git status"]);
+        type_text(&mut app, "git");
+        assert_eq!(selected(&app), "git status");
+        ctrl(&mut app, 'r');
+        assert_eq!(selected(&app), "git push");
+        ctrl(&mut app, 's');
+        assert_eq!(selected(&app), "git status");
+    }
+
+    #[test]
+    fn search_matches_any_line_and_scrolls_the_preview_to_it() {
+        let text: String = (0..20)
+            .map(|i| {
+                if i == 12 {
+                    "the needle\n".to_owned()
+                } else {
+                    format!("line {}\n", i)
+                }
+            })
+            .collect();
+        let mut app = app(&[&text]);
+        type_text(&mut app, "needle");
+        assert_eq!(app.matches, [Match { entry: 0, line: 12 }]);
+        assert_eq!(app.scroll, 12 - MATCH_CONTEXT);
+        assert!(render(&mut app, 100, 12).contains("the needle"));
+    }
+
+    #[test]
+    fn enter_copies_the_selection_and_escape_quits() {
+        let mut app = app(&["old", "new"]);
+        press(&mut app, KeyCode::Down);
+        assert_eq!(press(&mut app, KeyCode::Enter), Outcome::Copy(1));
+        assert_eq!(press(&mut app, KeyCode::Esc), Outcome::Quit);
+        assert_eq!(ctrl(&mut app, 'c'), Outcome::Quit);
+        type_text(&mut app, "nothing matches this");
+        assert_eq!(press(&mut app, KeyCode::Enter), Outcome::Continue);
+    }
+
+    #[test]
+    fn the_search_can_be_edited() {
+        let mut app = app(&["x"]);
+        type_text(&mut app, "foo bar");
+        ctrl(&mut app, 'w');
+        assert_eq!(app.query, "foo ");
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(app.query, "foo");
+        ctrl(&mut app, 'u');
+        assert_eq!(app.query, "");
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(matched(&app), ["x"]);
+    }
+
+    #[test]
+    fn renders_the_list_beside_a_numbered_preview() {
+        let mut app = App::new(
+            vec![Entry {
+                text: "fn main() {\n    println!(\"hi\");\n}".to_owned(),
+                source: Some("/src/main.rs".into()),
+                time: NOW - 120,
+            }],
+            test_highlighter(),
+            NOW,
+        );
+        let screen = render(&mut app, 100, 10);
+        assert!(screen.contains("History"), "{}", screen);
+        assert!(screen.contains("1/1"), "{}", screen);
+        assert!(screen.contains("  2m fn main() {"), "{}", screen);
+        assert!(screen.contains("main.rs · Rust · 3 lines"), "{}", screen);
+        assert!(screen.contains("1 │ fn main() {"), "{}", screen);
+        assert!(screen.contains("3 │ }"), "{}", screen);
+    }
+
+    #[test]
+    fn narrow_terminals_stack_the_panes() {
+        let mut app = app(&["hello"]);
+        let screen = render(&mut app, 40, 12);
+        let row = |needle| screen.lines().position(|line| line.contains(needle));
+        assert!(row("History") < row("Plain Text"), "{}", screen);
+    }
+
+    #[test]
+    fn says_when_nothing_matches() {
+        let mut app = app(&["hello"]);
+        type_text(&mut app, "zzz");
+        let screen = render(&mut app, 100, 10);
+        assert!(screen.contains("No matches"), "{}", screen);
+        assert!(screen.contains("0/1"), "{}", screen);
+    }
+
+    #[test]
+    fn escape_sequences_in_entries_are_shown_harmlessly() {
+        let mut app = app(&["\u{1b}[2Jgotcha"]);
+        let screen = render(&mut app, 100, 10);
+        assert!(!screen.contains('\u{1b}'));
+        assert!(screen.contains("\u{fffd}[2Jgotcha"), "{}", screen);
+    }
+
+    #[test]
+    fn ages_are_short() {
+        assert_eq!(age(NOW, NOW), "now");
+        assert_eq!(age(NOW, NOW - 59), "now");
+        assert_eq!(age(NOW, NOW - 60), "1m");
+        assert_eq!(age(NOW, NOW - 2 * 3600), "2h");
+        assert_eq!(age(NOW, NOW - 3 * 86400), "3d");
+        assert_eq!(age(NOW + 400 * 86400, NOW), "1y");
+        assert_eq!(age(NOW, NOW + 10), "now");
+    }
+
+    #[test]
+    fn find_ignores_case_across_multibyte_text() {
+        let text = "Grüße, WORLD";
+        let found = find(text, "world", false).unwrap();
+        assert_eq!(&text[found], "WORLD");
+        assert_eq!(find("ÄBC", "äb", false), Some(0..3));
+        assert_eq!(find("abc", "B", true), None);
+        assert_eq!(find("abc", "", false), None);
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,8 @@ use std::process::{Command, Output};
 fn cb(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_cb"))
         .args(args)
+        // Keep tests out of the real clipboard history.
+        .env("CB_HISTORY_FILE", "")
         .output()
         .expect("failed to run cb")
 }
@@ -25,6 +27,27 @@ fn help_prints_usage() {
         assert!(output.status.success(), "{}", stderr(&output));
         assert!(stdout(&output).starts_with("Usage: cb [FILE]"));
     }
+}
+
+#[test]
+fn help_mentions_peek() {
+    let output = cb(&["--help"]);
+    assert!(stdout(&output).contains("cb peek"));
+}
+
+#[test]
+fn peek_needs_a_terminal() {
+    // `output()` gives the child a null stdin and piped stdout.
+    let output = cb(&["peek"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stderr(&output), "cb: peek needs an interactive terminal\n");
+}
+
+#[test]
+fn peek_takes_no_arguments() {
+    let output = cb(&["peek", "1"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("unexpected argument '1'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds `cb peek`, an interactive picker over clipboard history. It's named `peek` to match the command the README already listed as upcoming.

```
┌ History ──────────────────────────── 4/5 ┐┌ Diff · 6 lines ────────────────────────────────────────────────┐
│ 10m for f in *.rs; do                    ││1 │ diff --git a/x.rs b/x.rs                                    │
│  1h diff --git a/x.rs b/x.rs             ││2 │ --- a/x.rs                                                  │
│  2h {"name": "clipboard", "version": "0.0││3 │ +++ b/x.rs                                                  │
│  2d //! Clipboard history: one JSON objec││4 │ @@ -1 +1 @@                                                 │
│                                          ││5 │ -old                                                        │
│                                          ││6 │ +new                                                        │
└──────────────────────────────────────────┘└────────────────────────────────────────────────────────────────┘
> rs                                                            ↑↓ select  ⏎ copy  PgUp/PgDn scroll  Esc quit
```

- **History** (`src/history.rs`): `cb` now records every copy, and whatever it finds on the clipboard when it prints it or opens `peek`. That's how copies made in other programs get in. Entries are stored as JSON lines in the platform data dir (`~/.local/share/cb/history.jsonl` on Linux). The file is `0600` and replaced atomically on each write. Repeated copies are deduplicated (moved to the top), and history keeps the last 500 entries of up to 1 MiB each. `CB_HISTORY_FILE` moves the file; setting it to an empty string turns history off.
- **Picker** (`src/peek.rs`, ratatui + crossterm): the list sits on the left with the newest entry first, and there's a preview on the right. Below 80 columns the panes stack instead. Typing filters with smart case, matching any line of an entry. The list row shows the line that matched, and the preview scrolls to it. Enter copies the selection and exits.
- **Preview** (`src/highlight.rs`): uses bat's own syntaxes and themes via [`two-face`](https://crates.io/crates/two-face), with line numbers like bat.
  - **Syntax detection:** by the name of the file the entry was copied from (`cb Cargo.toml` → TOML), then the first line (shebangs, `<?xml`), then diff/JSON sniffing for piped input.
  - **Lazy highlighting:** lines are highlighted as they scroll into view, so large entries open instantly.
  - **Theme and color:** the theme comes from `CB_THEME`, then `BAT_THEME`, defaulting to Monokai Extended. `NO_COLOR` turns colors off, and output falls back to 256 colors when `COLORTERM` doesn't advertise true color.
  - **Control characters** are replaced with `�`, so clipboard contents can't send escape sequences to the terminal.

| Key | Action |
| --- | --- |
| type | search every line of every entry |
| `↑` `↓` / `Ctrl-P` `Ctrl-N` | move |
| `Ctrl-R` / `Ctrl-S` | next older / newer match, as in a shell |
| `PgUp` `PgDn` / `Shift-↑` `Shift-↓` | scroll the preview |
| `Backspace` `Ctrl-W` `Ctrl-U` | edit the search |
| `Enter` | copy and exit |
| `Esc` `Ctrl-C` `Ctrl-G` | exit |

README, man page and `--help` are updated.

## Things to know

- **Binary size goes from 2.1 MB to 6.7 MB** (release, Linux x86_64). Almost all of that is bat's embedded syntax and theme dumps. Using syntect's built-in set instead would save most of it, but that set lacks TOML, TypeScript and Dockerfile, among others.
- **No clipboard watcher.** History only sees copies made through `cb`, plus whatever is on the clipboard when `cb` prints it or `peek` opens. A copy that's replaced before `cb` next runs won't be recorded.
- **`peek` is now a command.** `cb peek` used to copy a file named `peek`; that's now `cb ./peek`.
- **Concurrent writes:** two `cb` processes writing at the same moment can drop one entry, because the last writer wins. `std::fs::File::lock` would fix this, but it needs Rust 1.89 and the MSRV is 1.86.
- **Pasting into the search box:** without bracketed paste, a newline in pasted text acts as Enter.
- **MSRV:** the lockfile keeps `ratatui` at 0.30.0 (0.30.1+ needs Rust 1.88) and `time` at 0.3.45. I only built locally with stable 1.98, so the `min_version` CI job is the first check on 1.86.
- History can hold secrets; that's the reason for the `0600` file and the off switch.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` are all clean: 51 tests, 38 of them new. They cover the history store (dedup, cap, round trip, corrupt lines, file mode), syntax detection, color conversion, escape sanitizing, key handling and search, plus rendering through ratatui's `TestBackend`.
- I drove the release binary in a real pty with a VT emulator on Linux/Wayland, against a seeded history file:
  - It rendered the list and bat-colored previews for Rust, bash, diff and JSON.
  - Paging, smart-case search, Ctrl-R, scroll-to-match and "No matches" all behaved as expected.
  - The first frame appeared in 24–61 ms.
  - Enter re-copied an entry and the clipboard held it byte for byte afterwards.
  - With no display, the terminal was restored before the error was printed.
- Not tested by hand: macOS, Windows, X11. CI builds macOS and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan
