### PR TITLE
feat: add shell completions for bash, zsh and fish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,9 @@ jobs:
           # Man page
           cp 'doc/${{ env.PROJECT_BIN_NAME }}.1' "$ARCHIVE_DIR"
 
+          # Shell completions
+          cp -r completions "$ARCHIVE_DIR"
+
           # README, LICENSE and CHANGELOG files
           cp "README.md" "LICENSE" "CHANGELOG.md" "$ARCHIVE_DIR"
 
@@ -201,6 +204,11 @@ jobs:
           # Man page
           install -Dm644 'doc/${{ env.PROJECT_BIN_NAME }}.1' "${DPKG_DIR}/usr/share/man/man1/${{ env.PROJECT_BIN_NAME }}.1"
           gzip -n --best "${DPKG_DIR}/usr/share/man/man1/${{ env.PROJECT_BIN_NAME }}.1"
+
+          # Shell completions, where each shell looks for them
+          install -Dm644 completions/cb.bash "${DPKG_DIR}/usr/share/bash-completion/completions/${{ env.PROJECT_BIN_NAME }}"
+          install -Dm644 completions/_cb "${DPKG_DIR}/usr/share/zsh/vendor-completions/_${{ env.PROJECT_BIN_NAME }}"
+          install -Dm644 completions/cb.fish "${DPKG_DIR}/usr/share/fish/vendor_completions.d/${{ env.PROJECT_BIN_NAME }}.fish"
 
           # README and LICENSE
           install -Dm644 "README.md" "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/README.md"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ read: `~/.local/share/cb/history.jsonl` on Linux,
 somewhere else, or to an empty string to turn history off. The preview theme
 comes from `CB_THEME`, or else `BAT_THEME`.
 
+## Completions
+
+`cb` can tab-complete its commands, options and file names in bash, zsh and
+fish. Turn it on with one line in your shell's config:
+
+```bash
+# ~/.bashrc
+eval "$(cb completions bash)"
+
+# ~/.zshrc, after compinit
+source <(cb completions zsh)
+```
+
+In fish, save the script where fish looks for completions:
+
+```fish
+cb completions fish > ~/.config/fish/completions/cb.fish
+```
+
+The Debian package installs all three for you.
+
 ## Upcoming
 
 ```bash

--- a/completions/_cb
+++ b/completions/_cb
@@ -1,0 +1,43 @@
+#compdef cb
+
+# Completion for cb in zsh. Load it by adding this line to ~/.zshrc, after
+# compinit:
+#   source <(cb completions zsh)
+# or save it as _cb in a directory on $fpath.
+
+_cb() {
+  local -a commands=(
+    'peek:search clipboard history and copy an entry again'
+    'completions:print the completion script for a shell'
+  )
+  local -a options=(
+    '-h:print help' '--help:print help'
+    '-V:print version' '--version:print version'
+  )
+  local -a shells=(bash zsh fish)
+  local ret=1
+
+  case $CURRENT in
+    2)
+      if [[ $PREFIX == -* ]]; then
+        _describe -t options option options && ret=0
+      else
+        _describe -t commands command commands && ret=0
+        _files && ret=0
+      fi
+      ;;
+    3)
+      if [[ $words[2] == completions ]]; then
+        _describe -t shells shell shells && ret=0
+      fi
+      ;;
+  esac
+  return ret
+}
+
+# Autoloaded from $fpath, this file is the body of _cb; sourced, it registers it.
+if [[ $funcstack[1] == _cb ]]; then
+  _cb "$@"
+else
+  compdef _cb cb
+fi

--- a/completions/cb.bash
+++ b/completions/cb.bash
@@ -1,0 +1,31 @@
+# Completion for cb in bash. Load it by adding this line to ~/.bashrc:
+#   eval "$(cb completions bash)"
+#
+# Sticks to what bash 3.2, the version macOS ships, supports.
+
+_cb() {
+    local cur=$2 prev=$3
+    COMPREPLY=()
+    case $COMP_CWORD in
+    1)
+        if [[ $cur == -* ]]; then
+            COMPREPLY=($(compgen -W '-h --help -V --version' -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W 'peek completions' -- "$cur"))
+            # Read line by line so names with spaces stay whole.
+            local file
+            while IFS= read -r file; do
+                COMPREPLY+=("$file")
+            done < <(compgen -f -- "$cur")
+        fi
+        ;;
+    2)
+        if [[ $prev == completions ]]; then
+            COMPREPLY=($(compgen -W 'bash zsh fish' -- "$cur"))
+        fi
+        ;;
+    esac
+}
+
+# `filenames` quotes special characters and marks directories with a slash.
+complete -o filenames -F _cb cb

--- a/completions/cb.fish
+++ b/completions/cb.fish
@@ -1,0 +1,11 @@
+# Completion for cb in fish. Save it where fish looks for completions:
+#   cb completions fish > ~/.config/fish/completions/cb.fish
+
+# cb takes a single argument, so files are only offered for the first one.
+complete -c cb -f
+complete -c cb -n __fish_use_subcommand -F
+complete -c cb -n __fish_use_subcommand -a peek -d 'Search clipboard history and copy an entry again'
+complete -c cb -n __fish_use_subcommand -a completions -d 'Print the completion script for a shell'
+complete -c cb -n __fish_use_subcommand -s h -l help -d 'Print help'
+complete -c cb -n __fish_use_subcommand -s V -l version -d 'Print version'
+complete -c cb -n '__fish_seen_subcommand_from completions; and not __fish_seen_subcommand_from bash zsh fish' -a 'bash zsh fish'

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -8,6 +8,8 @@ cb \- a better command line clipboard
 \f[B]cb\f[R] [\f[I]FILE\f[R]]
 .br
 \f[B]cb peek\f[R]
+.br
+\f[B]cb completions\f[R] \f[I]SHELL\f[R]
 .SH DESCRIPTION
 .PP
 Copy \f[I]FILE\f[R], or whatever is piped in, to the system clipboard.
@@ -34,6 +36,13 @@ The syntax is picked from the name of the file the entry was copied
 from, or failing that, from its content.
 Needs an interactive terminal.
 To copy a file named \f[I]peek\f[R], use \f[B]cb ./peek\f[R].
+.TP
+\f[B]completions\f[R] \f[I]SHELL\f[R]
+Print the tab completion script for \f[I]SHELL\f[R], which is
+\f[B]bash\f[R], \f[B]zsh\f[R] or \f[B]fish\f[R].
+It completes commands, options and file names.
+To copy a file named \f[I]completions\f[R], use
+\f[B]cb ./completions\f[R].
 .PP
 In \f[B]peek\f[R]:
 .TP
@@ -88,6 +97,10 @@ cb | grep hello
 \f[B]Copy something from earlier\f[R]
 .PP
 cb peek
+.PP
+\f[B]Turn on tab completion in bash, from \[ti]/.bashrc\f[R]
+.PP
+eval \[dq]$(cb completions bash)\[dq]
 .SH ENVIRONMENT
 .TP
 \f[B]CB_HISTORY_FILE\f[R]

--- a/doc/cb.md
+++ b/doc/cb.md
@@ -28,3 +28,7 @@ cb | grep hello
 **Search clipboard history and copy an entry again**
 
 cb peek
+
+**Turn on tab completion in bash, from ~/.bashrc**
+
+eval "$(cb completions bash)"

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,32 @@
+//! Tab completion scripts, printed by `cb completions SHELL`.
+//!
+//! The scripts live in `completions/` so packages can install them as they are.
+
+/// The shells there are scripts for, as named in errors.
+pub const SHELLS: &str = "bash, zsh or fish";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl Shell {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "bash" => Some(Self::Bash),
+            "zsh" => Some(Self::Zsh),
+            "fish" => Some(Self::Fish),
+            _ => None,
+        }
+    }
+
+    pub fn script(self) -> &'static str {
+        match self {
+            Self::Bash => include_str!("../completions/cb.bash"),
+            Self::Zsh => include_str!("../completions/_cb"),
+            Self::Fish => include_str!("../completions/cb.fish"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ use std::process::ExitCode;
 
 use arboard::Clipboard;
 
+use crate::completions::Shell;
 use crate::highlight::Highlighter;
 
+mod completions;
 mod highlight;
 mod history;
 mod peek;
@@ -16,12 +18,14 @@ mod peek;
 const USAGE: &str = "\
 Usage: cb [FILE]
        cb peek
+       cb completions SHELL
 
 Copy FILE, or whatever is piped in, to the system clipboard.
 With no FILE and nothing piped in, print the clipboard.
 
 Commands:
   peek               Search clipboard history and copy an entry again
+  completions SHELL  Print tab completion for bash, zsh or fish
 
 Examples:
   cb package.json    Copy a file
@@ -49,37 +53,51 @@ enum Action {
     CopyFile(PathBuf),
     CopyStdin,
     Peek,
+    Completions(Shell),
 }
 
 /// Decides what to do from the arguments (excluding the program name).
 ///
 /// An explicit file always wins over stdin, so `cb notes.txt` behaves the same
 /// in a script or IDE task, where stdin is not a terminal, as it does at a prompt.
-/// `peek` is a command, so a file by that name is copied with `cb ./peek`.
+/// `peek` and `completions` are commands, so files by those names are copied
+/// with `cb ./peek` and `cb ./completions`.
 fn parse_args<I>(args: I, stdin_is_terminal: bool) -> Result<Action, String>
 where
     I: IntoIterator<Item = OsString>,
 {
     let mut args = args.into_iter();
-    let first = args.next();
-    if let Some(extra) = args.next() {
-        return Err(format!("unexpected argument '{}'", extra.to_string_lossy()));
-    }
-
-    let arg = match first {
+    let arg = match args.next() {
         Some(arg) => arg,
         None if stdin_is_terminal => return Ok(Action::Print),
         None => return Ok(Action::CopyStdin),
     };
-    match arg.to_str() {
-        Some("-h" | "--help") => Ok(Action::Help),
-        Some("-V" | "--version") => Ok(Action::Version),
-        Some("peek") => Ok(Action::Peek),
-        Some(flag) if flag.len() > 1 && flag.starts_with('-') => {
-            Err(format!("unknown option '{}'", flag))
+    let action = match arg.to_str() {
+        Some("-h" | "--help") => Action::Help,
+        Some("-V" | "--version") => Action::Version,
+        Some("peek") => Action::Peek,
+        Some("completions") => {
+            let name = args
+                .next()
+                .ok_or_else(|| format!("completions needs a shell: {}", completions::SHELLS))?;
+            let shell = name.to_str().and_then(Shell::from_name).ok_or_else(|| {
+                format!(
+                    "unknown shell '{}'; expected {}",
+                    name.to_string_lossy(),
+                    completions::SHELLS
+                )
+            })?;
+            Action::Completions(shell)
         }
-        _ => Ok(Action::CopyFile(PathBuf::from(arg))),
+        Some(flag) if flag.len() > 1 && flag.starts_with('-') => {
+            return Err(format!("unknown option '{}'", flag));
+        }
+        _ => Action::CopyFile(PathBuf::from(arg)),
+    };
+    if let Some(extra) = args.next() {
+        return Err(format!("unexpected argument '{}'", extra.to_string_lossy()));
     }
+    Ok(action)
 }
 
 /// Drops one trailing line ending.
@@ -123,6 +141,10 @@ fn run(action: Action) -> Result<(), String> {
             Ok(())
         }
         Action::Peek => peek(),
+        Action::Completions(shell) => {
+            print!("{}", shell.script());
+            Ok(())
+        }
     }
 }
 
@@ -337,6 +359,40 @@ mod tests {
         assert_eq!(
             parse(&["./peek"], true),
             Ok(Action::CopyFile(PathBuf::from("./peek")))
+        );
+    }
+
+    #[test]
+    fn completions_takes_a_shell() {
+        for (name, shell) in [
+            ("bash", Shell::Bash),
+            ("zsh", Shell::Zsh),
+            ("fish", Shell::Fish),
+        ] {
+            assert_eq!(
+                parse(&["completions", name], true),
+                Ok(Action::Completions(shell))
+            );
+        }
+        assert_eq!(
+            parse(&["./completions"], true),
+            Ok(Action::CopyFile(PathBuf::from("./completions")))
+        );
+    }
+
+    #[test]
+    fn completions_needs_one_known_shell() {
+        assert_eq!(
+            parse(&["completions"], true),
+            Err("completions needs a shell: bash, zsh or fish".into())
+        );
+        assert_eq!(
+            parse(&["completions", "tcsh"], true),
+            Err("unknown shell 'tcsh'; expected bash, zsh or fish".into())
+        );
+        assert_eq!(
+            parse(&["completions", "zsh", "bash"], true),
+            Err("unexpected argument 'bash'".into())
         );
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -36,6 +36,99 @@ fn help_mentions_peek() {
 }
 
 #[test]
+fn help_mentions_completions() {
+    let output = cb(&["--help"]);
+    assert!(stdout(&output).contains("cb completions SHELL"));
+}
+
+#[test]
+fn completions_prints_the_script_for_each_shell() {
+    for (shell, script) in [
+        ("bash", include_str!("../completions/cb.bash")),
+        ("zsh", include_str!("../completions/_cb")),
+        ("fish", include_str!("../completions/cb.fish")),
+    ] {
+        let output = cb(&["completions", shell]);
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert_eq!(stdout(&output), script);
+    }
+}
+
+#[test]
+fn completions_for_an_unknown_shell_is_a_usage_error() {
+    let output = cb(&["completions", "tcsh"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("unknown shell 'tcsh'"));
+}
+
+/// Runs the bash completion script the way bash does on Tab.
+#[cfg(unix)]
+mod bash_completion {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Completes the last of `words`, typed after `cb`, in a directory holding
+    /// `notes.txt` and `src/`.
+    fn complete(words: &[&str]) -> Vec<String> {
+        let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("bash-completion");
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(dir.join("notes.txt"), "").unwrap();
+
+        let script = stdout(&cb(&["completions", "bash"]));
+        let driver = r#"
+COMP_WORDS=(cb "$@")
+COMP_CWORD=$#
+_cb cb "${COMP_WORDS[COMP_CWORD]}" "${COMP_WORDS[COMP_CWORD-1]}"
+printf '%s\n' "${COMPREPLY[@]}"
+"#;
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(script + driver)
+            .arg("bash")
+            .args(words)
+            .current_dir(&dir)
+            .output()
+            .expect("failed to run bash");
+        assert!(output.status.success(), "{}", stderr(&output));
+
+        let mut completions: Vec<String> = stdout(&output)
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
+            .collect();
+        completions.sort();
+        completions
+    }
+
+    #[test]
+    fn first_argument_is_a_command_or_a_file() {
+        assert_eq!(complete(&[""]), ["completions", "notes.txt", "peek", "src"]);
+        assert_eq!(complete(&["p"]), ["peek"]);
+        assert_eq!(complete(&["no"]), ["notes.txt"]);
+    }
+
+    #[test]
+    fn a_dash_completes_options() {
+        assert_eq!(complete(&["-"]), ["--help", "--version", "-V", "-h"]);
+        assert_eq!(complete(&["--v"]), ["--version"]);
+    }
+
+    #[test]
+    fn completions_is_followed_by_a_shell() {
+        assert_eq!(complete(&["completions", ""]), ["bash", "fish", "zsh"]);
+        assert_eq!(complete(&["completions", "z"]), ["zsh"]);
+    }
+
+    #[test]
+    fn nothing_follows_a_complete_command_line() {
+        assert!(complete(&["peek", ""]).is_empty());
+        assert!(complete(&["notes.txt", ""]).is_empty());
+        assert!(complete(&["completions", "zsh", ""]).is_empty());
+    }
+}
+
+#[test]
 fn peek_needs_a_terminal() {
     // `output()` gives the child a null stdin and piped stdout.
     let output = cb(&["peek"]);


### PR DESCRIPTION
## Summary
- `cb completions SHELL` prints a tab completion script for bash, zsh or fish. It completes `peek`, `completions` and file names for the first argument, the options after a `-`, and the shell name after `completions`. Since `cb` takes one argument, it offers nothing after that.
- The scripts are plain files in `completions/`, embedded with `include_str!`. CI adds them to the release archives and installs them in the Debian package where each shell looks for them (`bash-completion/completions`, `zsh/vendor-completions`, `fish/vendor_completions.d`).
- The help text, man page, `doc/cb.md` and README cover setup: one line in `~/.bashrc` or `~/.zshrc`, or saving the fish script.

**Behavior change:** like `peek`, `completions` is now a command, so a file with that name is copied with `cb ./completions`.

## Testing
- `cargo fmt --check`, clippy (no warnings) and `cargo test`: all 60 tests pass.
- New integration tests source the bash script and check what it offers at each position. They run on Unix only, so the macOS job covers bash 3.2.
- zsh: syntax-checked with `zsh -n` only; not yet tried in an interactive shell.
- fish: not run, since fish wasn't available locally.
- The CI packaging steps are untested until this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiHQ2M7NYyVY5Z8LtzhRoz
