### PR TITLE
feat: sort cb peek by frecency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,24 @@ cb --help
 
 `cb` remembers what it copies, and what it finds on the clipboard when it
 prints it. To record everything you copy, in any program, run
-[`cb watch`](#recording-everything-you-copy). `cb peek` opens that history: newest first on the left, and on the right a preview of the selected
-entry, syntax highlighted with [bat](https://github.com/sharkdp/bat)'s syntaxes
+[`cb watch`](#recording-everything-you-copy). `cb peek` opens that history, with a preview of the selected entry on the right, syntax highlighted with [bat](https://github.com/sharkdp/bat)'s syntaxes
 and themes.
 
 | Key                         | Action                                     |
 | --------------------------- | ------------------------------------------ |
 | Type                        | Search every line of every entry           |
 | `↑` `↓`                     | Move through the entries                   |
-| `Ctrl-R` `Ctrl-S`           | Step to the next older or newer match      |
+| `Ctrl-R` `Ctrl-S`           | Step to the next or previous match         |
 | `PgUp` `PgDn`, `Shift-↑` `Shift-↓` | Scroll the preview                  |
 | `Backspace` `Ctrl-W` `Ctrl-U` | Delete a character, a word, or the search |
 | `Enter`                     | Copy the selected entry and exit           |
 | `Esc`, `Ctrl-C`             | Exit without copying                       |
 
-The search is case-sensitive only if it contains an uppercase letter.
+Entries are ordered by frecency, how often and how recently you've copied
+them: each copy adds to an entry's score, which halves for every day it goes
+unused. What you copy often stays near the top, and old favorites sink within
+days. Matches keep that order as you search, which is case-sensitive only if it
+contains an uppercase letter.
 
 History holds the last 500 copies, up to 1 MiB each, in a file only you can
 read: `~/.local/share/cb/history.jsonl` on Linux,

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -37,10 +37,12 @@ on Windows.
 .TP
 \f[B]peek\f[R]
 Search clipboard history and copy an entry again.
-Entries are listed newest first, with a preview of the selected one,
+Entries are listed by frecency, with a preview of the selected one,
 syntax highlighted with the syntaxes and themes of \f[B]bat\f[R](1).
 The syntax is picked from the name of the file the entry was copied
 from, or failing that, from its content.
+Frecency counts how often and how recently an entry was copied: each copy
+adds to its score, which halves for every day it goes unused.
 Needs an interactive terminal.
 To copy a file named \f[I]peek\f[R], use \f[B]cb ./peek\f[R].
 .TP
@@ -61,7 +63,7 @@ The search is case\-sensitive only if it contains an uppercase letter.
 Move through the entries.
 .TP
 \f[B]Ctrl\-R\f[R], \f[B]Ctrl\-S\f[R]
-Step to the next older or newer match.
+Step to the next or previous match.
 .TP
 \f[B]PgUp\f[R], \f[B]PgDn\f[R], \f[B]Shift\-Up\f[R], \f[B]Shift\-Down\f[R]
 Scroll the preview.

--- a/src/history.rs
+++ b/src/history.rs
@@ -19,14 +19,53 @@ const MAX_ENTRIES: usize = 500;
 /// Larger copies aren't kept, so that reading history stays fast.
 const MAX_ENTRY_BYTES: usize = 1024 * 1024;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// How long an unused entry takes to lose half its frecency, in seconds.
+const HALF_LIFE: u64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Entry {
     pub text: String,
     /// The file the text was copied from, used to pick a syntax for its preview.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<PathBuf>,
-    /// When it was copied, in seconds since the Unix epoch.
+    /// When it was last used, in seconds since the Unix epoch.
     pub time: u64,
+    /// How many times it has been used. History from before this was kept
+    /// counts each entry once.
+    #[serde(default = "one")]
+    pub uses: u32,
+    /// Its frecency as of `time`. See `frecency`.
+    #[serde(default = "one_score")]
+    pub score: f64,
+}
+
+fn one() -> u32 {
+    1
+}
+
+fn one_score() -> f64 {
+    1.0
+}
+
+impl Entry {
+    /// How often and how recently the entry has been used, as of `now`. Each
+    /// use adds 1, and the total halves every `HALF_LIFE` the entry goes
+    /// unused, so a favorite that falls out of use sinks within days.
+    pub fn frecency(&self, now: u64) -> f64 {
+        let idle = now.saturating_sub(self.time) as f64;
+        self.score * 0.5_f64.powf(idle / HALF_LIFE as f64)
+    }
+}
+
+/// How text came to be recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Use {
+    /// cb copied it, which always counts as a use.
+    Copied,
+    /// It was found on the clipboard. That is read far more often than it
+    /// changes, and whatever cb copies is found there right after, so this
+    /// only counts when the text isn't already the newest entry.
+    Seen,
 }
 
 /// The history file, or `None` if history is turned off.
@@ -58,19 +97,16 @@ pub fn now() -> u64 {
         .map_or(0, |elapsed| elapsed.as_secs())
 }
 
-/// Adds `text` to history as the newest entry, unless history is turned off.
-pub fn record(text: &str, source: Option<&Path>) -> Result<(), String> {
+/// Records a use of `text` in history, unless history is turned off.
+pub fn record(text: &str, source: Option<&Path>, how: Use) -> Result<(), String> {
     let Some(path) = path() else {
         return Ok(());
     };
-    let entry = Entry {
-        text: text.to_owned(),
-        source: source.map(|source| fs::canonicalize(source).unwrap_or_else(|_| source.to_owned())),
-        time: now(),
-    };
+    let source =
+        source.map(|source| fs::canonicalize(source).unwrap_or_else(|_| source.to_owned()));
     let context = |e: io::Error| format!("{}: {}", path.display(), e);
     let mut entries = load(&path).map_err(context)?;
-    if push(&mut entries, entry) {
+    if push(&mut entries, text, source, how, now()) {
         save(&path, &entries).map_err(context)
     } else {
         Ok(())
@@ -94,23 +130,30 @@ pub fn load(path: &Path) -> io::Result<Vec<Entry>> {
     Ok(entries)
 }
 
-/// Adds `entry` as the newest, replacing any earlier copy of the same text and
-/// dropping the oldest entries past the limit. Returns whether anything changed:
-/// empty and oversized text isn't kept, and text that is already the newest
-/// entry is left alone.
-fn push(entries: &mut Vec<Entry>, mut entry: Entry) -> bool {
-    if entry.text.is_empty() || entry.text.len() > MAX_ENTRY_BYTES {
+/// Records a use of `text` at `now` as the newest entry, carrying over the
+/// uses and frecency of any earlier entry for the same text, and drops the
+/// oldest entries past the limit. Returns whether anything changed: empty and
+/// oversized text isn't kept, and seeing the newest entry again isn't a use.
+fn push(entries: &mut Vec<Entry>, text: &str, source: Option<PathBuf>, how: Use, now: u64) -> bool {
+    if text.is_empty() || text.len() > MAX_ENTRY_BYTES {
         return false;
     }
-    if entries.last().is_some_and(|last| {
-        last.text == entry.text && (entry.source.is_none() || entry.source == last.source)
-    }) {
+    if how == Use::Seen && entries.last().is_some_and(|last| last.text == text) {
         return false;
     }
-    if let Some(index) = entries.iter().rposition(|old| old.text == entry.text) {
+    let mut entry = Entry {
+        text: text.to_owned(),
+        source,
+        time: now,
+        uses: 1,
+        score: 1.0,
+    };
+    if let Some(index) = entries.iter().rposition(|old| old.text == text) {
+        let old = entries.remove(index);
+        entry.uses = entry.uses.saturating_add(old.uses);
+        entry.score += old.frecency(now);
         // Printing the clipboard records it without a source; keep the file
         // it originally came from so the preview still knows its syntax.
-        let old = entries.remove(index);
         entry.source = entry.source.or(old.source);
     }
     entries.push(entry);
@@ -158,16 +201,24 @@ fn create_private(path: &Path) -> io::Result<File> {
 mod tests {
     use super::*;
 
+    const DAY: u64 = HALF_LIFE;
+
     fn entry(text: &str, time: u64) -> Entry {
         Entry {
             text: text.to_owned(),
             source: None,
             time,
+            uses: 1,
+            score: 1.0,
         }
     }
 
     fn texts(entries: &[Entry]) -> Vec<&str> {
         entries.iter().map(|entry| entry.text.as_str()).collect()
+    }
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
     }
 
     /// A path in the temp directory that no other test uses.
@@ -178,16 +229,37 @@ mod tests {
     #[test]
     fn push_adds_the_newest_entry_last() {
         let mut entries = vec![entry("a", 1)];
-        assert!(push(&mut entries, entry("b", 2)));
+        assert!(push(&mut entries, "b", None, Use::Copied, 2));
         assert_eq!(texts(&entries), ["a", "b"]);
+        assert_eq!(entries[1], entry("b", 2));
     }
 
     #[test]
-    fn push_moves_a_repeated_copy_to_the_end() {
-        let mut entries = vec![entry("a", 1), entry("b", 2)];
-        assert!(push(&mut entries, entry("a", 3)));
+    fn using_an_entry_again_moves_it_to_the_end_and_adds_up() {
+        let mut entries = vec![entry("a", 0), entry("b", 0)];
+        assert!(push(&mut entries, "a", None, Use::Copied, DAY));
         assert_eq!(texts(&entries), ["b", "a"]);
-        assert_eq!(entries[1].time, 3);
+        let a = &entries[1];
+        assert_eq!((a.time, a.uses), (DAY, 2));
+        // The first use lost half its weight in the day before the second.
+        assert!(close(a.score, 1.5), "{}", a.score);
+    }
+
+    #[test]
+    fn copying_the_newest_entry_again_counts_but_seeing_it_does_not() {
+        let mut entries = vec![entry("a", 1)];
+        assert!(!push(&mut entries, "a", None, Use::Seen, 2));
+        assert_eq!(entries[0].uses, 1);
+        assert!(push(&mut entries, "a", None, Use::Copied, 2));
+        assert_eq!(entries[0].uses, 2);
+    }
+
+    #[test]
+    fn seeing_an_older_entry_counts() {
+        let mut entries = vec![entry("a", 1), entry("b", 2)];
+        assert!(push(&mut entries, "a", None, Use::Seen, 3));
+        assert_eq!(texts(&entries), ["b", "a"]);
+        assert_eq!(entries[1].uses, 2);
     }
 
     #[test]
@@ -199,19 +271,16 @@ mod tests {
             },
             entry("b", 2),
         ];
-        assert!(push(&mut entries, entry("fn main() {}", 3)));
+        assert!(push(&mut entries, "fn main() {}", None, Use::Seen, 3));
         assert_eq!(entries[1].source, Some("main.rs".into()));
     }
 
     #[test]
-    fn push_ignores_empty_oversized_and_unchanged_text() {
+    fn push_ignores_empty_and_oversized_text() {
         let mut entries = vec![entry("a", 1)];
-        assert!(!push(&mut entries, entry("", 2)));
-        assert!(!push(
-            &mut entries,
-            entry(&"x".repeat(MAX_ENTRY_BYTES + 1), 2)
-        ));
-        assert!(!push(&mut entries, entry("a", 2)));
+        assert!(!push(&mut entries, "", None, Use::Copied, 2));
+        let huge = "x".repeat(MAX_ENTRY_BYTES + 1);
+        assert!(!push(&mut entries, &huge, None, Use::Copied, 2));
         assert_eq!(entries, [entry("a", 1)]);
     }
 
@@ -220,10 +289,31 @@ mod tests {
         let mut entries = (0..MAX_ENTRIES as u64)
             .map(|i| entry(&i.to_string(), i))
             .collect();
-        assert!(push(&mut entries, entry("new", 1000)));
+        assert!(push(&mut entries, "new", None, Use::Copied, 1000));
         assert_eq!(entries.len(), MAX_ENTRIES);
         assert_eq!(entries[0].text, "1");
         assert_eq!(entries[MAX_ENTRIES - 1].text, "new");
+    }
+
+    #[test]
+    fn frecency_halves_every_day_unused() {
+        let a = Entry {
+            score: 4.0,
+            ..entry("a", DAY)
+        };
+        assert!(close(a.frecency(DAY), 4.0));
+        assert!(close(a.frecency(2 * DAY), 2.0));
+        assert!(close(a.frecency(3 * DAY), 1.0));
+        // A clock set back doesn't inflate it.
+        assert!(close(a.frecency(0), 4.0));
+    }
+
+    #[test]
+    fn history_from_before_frecency_still_loads() {
+        let path = temp_path("old-format.jsonl");
+        fs::write(&path, "{\"text\":\"old\",\"time\":5}\n").unwrap();
+        assert_eq!(load(&path).unwrap(), [entry("old", 5)]);
+        fs::remove_file(path).unwrap();
     }
 
     #[test]
@@ -233,6 +323,8 @@ mod tests {
         let entries = vec![
             Entry {
                 source: Some("/tmp/a.rs".into()),
+                uses: 3,
+                score: 2.25,
                 ..entry("line one\n\t\"quoted\"\nline three", 1)
             },
             entry("second", 2),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use arboard::Clipboard;
 
 use crate::completions::Shell;
 use crate::highlight::Highlighter;
+use crate::history::Use;
 
 mod completions;
 mod highlight;
@@ -153,7 +154,7 @@ fn run(action: Action) -> Result<(), String> {
                 fs::read_to_string(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
             let text = strip_trailing_newline(&text);
             copy(text)?;
-            remember(text, Some(&path));
+            remember(text, Some(&path), Use::Copied);
             Ok(())
         }
         Action::CopyStdin => {
@@ -163,7 +164,7 @@ fn run(action: Action) -> Result<(), String> {
                 .map_err(|e| format!("stdin: {}", e))?;
             let text = strip_trailing_newline(&text);
             copy(text)?;
-            remember(text, None);
+            remember(text, None, Use::Copied);
             Ok(())
         }
         Action::Peek => peek(),
@@ -178,8 +179,8 @@ fn run(action: Action) -> Result<(), String> {
 }
 
 /// Adds text to history. Failing to is worth a warning, not a failed copy.
-fn remember(text: &str, source: Option<&Path>) {
-    if let Err(message) = history::record(text, source) {
+fn remember(text: &str, source: Option<&Path>, how: Use) {
+    if let Err(message) = history::record(text, source, how) {
         eprintln!("cb: warning: could not save history: {}", message);
     }
 }
@@ -188,7 +189,7 @@ fn remember(text: &str, source: Option<&Path>) {
 /// asked for it not to be kept, as password managers do.
 fn remember_clipboard(text: &str) {
     if !platform::is_concealed() {
-        remember(text, None);
+        remember(text, None, Use::Seen);
     }
 }
 
@@ -211,7 +212,7 @@ fn peek() -> Result<(), String> {
         return Ok(());
     };
     copy(&entry.text)?;
-    remember(&entry.text, entry.source.as_deref());
+    remember(&entry.text, entry.source.as_deref(), Use::Copied);
     Ok(())
 }
 

--- a/src/peek.rs
+++ b/src/peek.rs
@@ -56,7 +56,7 @@ enum Outcome {
 }
 
 struct App<'a> {
-    /// Newest first.
+    /// The most frecent first.
     entries: Vec<Entry>,
     /// Lowercased copies of `entries`, for case-insensitive search.
     lowercase: Vec<String>,
@@ -75,7 +75,9 @@ struct App<'a> {
 
 impl<'a> App<'a> {
     fn new(mut entries: Vec<Entry>, highlighter: &'a Highlighter, now: u64) -> Self {
+        // The most frecent first, and of two equals, the newer.
         entries.reverse();
+        entries.sort_by(|a, b| b.frecency(now).total_cmp(&a.frecency(now)));
         let lowercase = entries
             .iter()
             .map(|entry| entry.text.to_lowercase())
@@ -130,8 +132,8 @@ impl<'a> App<'a> {
             KeyCode::Down if shift => self.scroll_by(1),
             KeyCode::Up => self.move_by(-1),
             KeyCode::Down => self.move_by(1),
-            // As in a shell, Ctrl-R searches further back and Ctrl-S comes
-            // forward again.
+            // As in a shell's history search, Ctrl-R moves on to the next
+            // match and Ctrl-S back to the previous one.
             KeyCode::Char('r' | 'n') if ctrl => self.move_by(1),
             KeyCode::Char('s' | 'p') if ctrl => self.move_by(-1),
             KeyCode::PageUp => self.scroll_by(-page),
@@ -170,8 +172,8 @@ impl<'a> App<'a> {
         self.query.chars().any(char::is_uppercase)
     }
 
-    /// Finds the entries that match the search, newest first, and selects the
-    /// newest.
+    /// Finds the entries that match the search, keeping them in frecency
+    /// order, and selects the first.
     fn filter(&mut self) {
         let case_sensitive = self.case_sensitive();
         let query = if case_sensitive {
@@ -316,6 +318,9 @@ impl<'a> App<'a> {
             1 => "1 line".to_owned(),
             n => format!("{} lines", n),
         });
+        if entry.uses > 1 {
+            title.push(format!("copied {} times", entry.uses));
+        }
         let mut title_spans = Vec::new();
         push_span(
             &mut title_spans,
@@ -437,6 +442,8 @@ mod tests {
                 text: (*text).to_owned(),
                 source: None,
                 time: NOW - 60 * (texts.len() - i) as u64,
+                uses: 1,
+                score: 1.0,
             })
             .collect();
         App::new(entries, test_highlighter(), NOW)
@@ -565,6 +572,8 @@ mod tests {
                 text: "fn main() {\n    println!(\"hi\");\n}".to_owned(),
                 source: Some("/src/main.rs".into()),
                 time: NOW - 120,
+                uses: 1,
+                score: 1.0,
             }],
             test_highlighter(),
             NOW,
@@ -601,6 +610,60 @@ mod tests {
         let screen = render(&mut app, 100, 10);
         assert!(!screen.contains('\u{1b}'));
         assert!(screen.contains("\u{fffd}[2Jgotcha"), "{}", screen);
+    }
+
+    /// An entry used `uses` times, last `idle` seconds ago, each use then.
+    fn used(text: &str, uses: u32, idle: u64) -> Entry {
+        Entry {
+            text: text.to_owned(),
+            source: None,
+            time: NOW - idle,
+            uses,
+            score: uses.into(),
+        }
+    }
+
+    #[test]
+    fn entries_used_often_come_before_newer_ones() {
+        let app = App::new(
+            vec![used("favorite", 5, 3600), used("once", 1, 60)],
+            test_highlighter(),
+            NOW,
+        );
+        assert_eq!(matched(&app), ["favorite", "once"]);
+        assert_eq!(selected(&app), "favorite");
+    }
+
+    #[test]
+    fn favorites_sink_once_they_go_unused() {
+        let app = App::new(
+            vec![used("old favorite", 20, 10 * 86400), used("once", 1, 60)],
+            test_highlighter(),
+            NOW,
+        );
+        assert_eq!(matched(&app), ["once", "old favorite"]);
+    }
+
+    #[test]
+    fn matches_stay_in_frecency_order() {
+        let mut app = App::new(
+            vec![
+                used("git push", 4, 3600),
+                used("ls", 9, 60),
+                used("git status", 1, 60),
+            ],
+            test_highlighter(),
+            NOW,
+        );
+        type_text(&mut app, "git");
+        assert_eq!(matched(&app), ["git push", "git status"]);
+    }
+
+    #[test]
+    fn the_preview_says_how_often_an_entry_was_copied() {
+        let mut app = App::new(vec![used("hello", 3, 60)], test_highlighter(), NOW);
+        let screen = render(&mut app, 100, 10);
+        assert!(screen.contains("copied 3 times"), "{}", screen);
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use arboard::Clipboard;
 
-use crate::{history, platform, remember};
+use crate::history::{self, Use};
+use crate::{platform, remember};
 
 /// How often to look at the clipboard.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -41,7 +42,7 @@ pub fn run() -> Result<(), String> {
                 Ok(text) => {
                     seen_change = change;
                     if watcher.observe(Some(&text), platform::is_concealed) {
-                        remember(&text, None);
+                        remember(&text, None, Use::Seen);
                     }
                 }
                 // Empty, or holding something other than text.


### PR DESCRIPTION
## Summary

`cb peek` now lists entries by **frecency**, meaning how often and how recently you've copied them, instead of newest first. Snippets you reuse stay near the top, and old favorites sink within days.

**Stacked on #24:** this PR's base is `feat/watch`. Merge #24 first; GitHub will then retarget this PR to `main`.

- **How the score works:** each entry now keeps a use count and a score. Every use adds 1 to the score, and the score halves for each day the entry goes unused. That's exact exponential-decay frecency with two numbers per entry.
  - An entry copied 5 times over the past day outranks one copied once a minute ago.
  - An entry copied 20 times ten days ago has decayed to about 0.02, so anything recent beats it.
- **What counts as a use:**
  - Copying through `cb` (a file, piped text, or Enter in `cb peek`) always counts.
  - Text found on the clipboard, by `cb watch` or when `cb` prints it, counts only if it isn't already the newest entry. Otherwise the watcher would count every `cb` copy twice, and printing the clipboard would count as using it.
- **Picker changes:**
  - Matches keep frecency order while you search.
  - Ctrl-R and Ctrl-S now step to the next and previous match.
  - The preview title shows "copied N times" for entries used more than once.
- **Compatible with existing history files:** entries without the new fields load as used once. Removing the oldest entries past 500 still goes by last use.
- README and man page are updated.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` are clean: 82 tests, 8 of them new. They cover:
  - decay (halving per day, ignoring a clock set back)
  - counting copies versus sightings of the clipboard, and moving a reused entry to the end
  - loading pre-frecency history files
  - picker order: favorites above newer one-offs, stale favorites sinking, matches keeping that order, and the "copied N times" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan
