### PR TITLE
feat: watch the clipboard through native change notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,9 @@ dependencies = [
  "serde_json",
  "syntect",
  "two-face",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -122,6 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+ "windows-win",
 ]
 
 [[package]]
@@ -1352,6 +1356,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-win"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e23e33622b3b52f948049acbec9bcc34bf6e26d74176b88941f213c75cf2dc"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,19 @@ syntect = { version = "5.3", default-features = false, features = ["parsing", "r
 # bat's syntaxes and themes, so previews look the way they do in `bat`.
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 
-# Platform clipboard APIs that arboard already builds on, for the checks it
-# doesn't offer: whether a copy is marked as secret, and whether it changed.
+# Platform clipboard APIs that arboard already builds on, for what it doesn't
+# offer: whether a copy is marked as secret, and word of when the clipboard
+# changes.
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))'.dependencies]
+wayland-client = "0.31"
+wayland-protocols = { version = "0.32", features = ["client", "staging"] }
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 wl-clipboard-rs = "0.9"
-x11rb = "0.13"
+x11rb = { version = "0.13", features = ["xfixes"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSPasteboard"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSArray", "NSString"] }
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = "5.4"
+clipboard-win = { version = "5.4", features = ["monitor"] }

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ comes from `CB_THEME`, or else `BAT_THEME`.
 
 ### Recording everything you copy
 
-`cb` on its own only sees the clipboard when you run it. `cb watch` checks it
-every 2 seconds and records each new text copy, whichever program made it:
+`cb` on its own only sees the clipboard when you run it. `cb watch` records
+each new text copy as it's made, whichever program made it. It listens for
+the system's clipboard notifications on X11, on Wayland compositors with the
+data-control protocol (KDE, sway, Hyprland and most others), and on Windows.
+Where there are none, as on macOS, it checks every 2 seconds.
 
 ```bash
 cb watch --install     # start now, and whenever you log in
@@ -89,7 +92,8 @@ Copies that password managers mark as secret are never recorded, by `cb watch`
 or anything else in `cb`: the `x-kde-passwordManagerHint` type on Linux, the
 [nspasteboard.org](http://nspasteboard.org) types on macOS, and
 `ExcludeClipboardContentFromMonitorProcessing` and its relatives on Windows.
-Only text is recorded, and a copy replaced within 2 seconds may be missed.
+Only text is recorded, and where `cb` has to check every 2 seconds, a copy
+replaced sooner may be missed.
 
 ## Completions
 

--- a/completions/_cb
+++ b/completions/_cb
@@ -8,7 +8,7 @@
 _cb() {
   local -a commands=(
     'peek:search clipboard history and copy an entry again'
-    'watch:record everything copied, checking every 2 seconds'
+    'watch:record everything copied, in any program'
     'completions:print the completion script for a shell'
   )
   local -a options=(

--- a/completions/cb.fish
+++ b/completions/cb.fish
@@ -5,7 +5,7 @@
 complete -c cb -f
 complete -c cb -n __fish_use_subcommand -F
 complete -c cb -n __fish_use_subcommand -a peek -d 'Search clipboard history and copy an entry again'
-complete -c cb -n __fish_use_subcommand -a watch -d 'Record everything copied, checking every 2 seconds'
+complete -c cb -n __fish_use_subcommand -a watch -d 'Record everything copied, in any program'
 complete -c cb -n __fish_use_subcommand -a completions -d 'Print the completion script for a shell'
 complete -c cb -n __fish_use_subcommand -s h -l help -d 'Print help'
 complete -c cb -n __fish_use_subcommand -s V -l version -d 'Print version'

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -78,11 +78,13 @@ Copy the selected entry and exit.
 Exit without copying.
 .TP
 \f[B]watch\f[R]
-Check the clipboard every 2 seconds and record each new text copy,
-whichever program made it, until stopped with Ctrl\-C or
-\f[B]\-\-uninstall\f[R].
+Record each new text copy as it's made, whichever program made it,
+until stopped with Ctrl\-C or \f[B]\-\-uninstall\f[R].
+\f[B]cb\f[R] listens for the system's clipboard notifications on X11,
+on Wayland compositors with the data\-control protocol, and on Windows.
+Where there are none, as on macOS, it checks every 2 seconds, and a copy
+replaced sooner may be missed.
 Only one watcher runs at a time.
-A copy replaced within 2 seconds may be missed.
 .RS
 .TP
 \f[B]\-\-install\f[R]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ With no FILE and nothing piped in, print the clipboard.
 
 Commands:
   peek               Search clipboard history and copy an entry again
-  watch              Record everything copied, checking every 2 seconds
+  watch              Record everything copied, in any program
     --install        Also start watching whenever you log in
     --uninstall      Stop watching, now and at login
   completions SHELL  Print tab completion for bash, zsh or fish

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,11 +1,11 @@
 //! Clipboard questions arboard doesn't answer, asked the way each platform
 //! expects: whether a copy was marked as not to be recorded, as password
-//! managers do, and whether the clipboard changed at all.
+//! managers do, and when the clipboard changes.
 //!
 //! When the check itself fails, the copy is taken to be unmarked. Otherwise
 //! history would stop working anywhere the check can't run.
 
-pub use imp::{change_count, is_concealed};
+pub use imp::{change_count, is_concealed, Changes};
 
 /// Linux and the BSDs, on X11 or Wayland.
 #[cfg(all(
@@ -14,23 +14,15 @@ pub use imp::{change_count, is_concealed};
 ))]
 mod imp {
     use std::env;
-    use std::thread;
-    use std::time::{Duration, Instant};
 
     use wl_clipboard_rs::paste::{get_mime_types, ClipboardType, Seat};
-    use x11rb::connection::Connection;
-    use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, WindowClass};
-    use x11rb::protocol::Event;
 
     /// Introduced by KDE's clipboard manager, and set by password managers
     /// like KeePassXC.
     const HINT: &str = "x-kde-passwordManagerHint";
 
-    /// How long the clipboard's owner gets to list what it offers.
-    const TIMEOUT: Duration = Duration::from_millis(500);
-
-    /// X11 and Wayland have no cheap change counter, so the watcher reads the
-    /// clipboard every time.
+    /// X11 and Wayland have no cheap change counter; they announce changes
+    /// instead.
     pub fn change_count() -> Option<u64> {
         None
     }
@@ -45,69 +37,307 @@ mod imp {
                 return types.contains(HINT);
             }
         }
-        x11_offers(HINT).unwrap_or(false)
+        x11::offers(HINT).unwrap_or(false)
     }
 
-    /// Whether the owner of the X11 clipboard lists `target` among the
-    /// formats it offers.
-    fn x11_offers(target: &str) -> Option<bool> {
-        let (conn, screen) = x11rb::connect(None).ok()?;
-        let atom = |name: &str, only_if_exists: bool| -> Option<u32> {
-            let cookie = conn.intern_atom(only_if_exists, name.as_bytes()).ok()?;
-            Some(cookie.reply().ok()?.atom)
-        };
-        // Nobody can offer a format that no program has named.
-        let target = atom(target, true)?;
-        if target == x11rb::NONE {
-            return Some(false);
-        }
-        let clipboard = atom("CLIPBOARD", false)?;
-        let targets = atom("TARGETS", false)?;
-        let property = atom("CB_TARGETS", false)?;
+    /// Announcements of clipboard changes. They come from Wayland's
+    /// data-control protocol where the compositor has it, since that's where
+    /// arboard reads the clipboard too, and otherwise from X11's XFixes
+    /// extension, which XWayland also serves.
+    pub enum Changes {
+        Wayland(wayland::Changes),
+        X11(Box<x11::Changes>),
+    }
 
-        let window = conn.generate_id().ok()?;
-        let root = conn.setup().roots.get(screen)?.root;
-        conn.create_window(
-            x11rb::COPY_DEPTH_FROM_PARENT,
-            window,
-            root,
-            0,
-            0,
-            1,
-            1,
-            0,
-            WindowClass::INPUT_ONLY,
-            x11rb::COPY_FROM_PARENT,
-            &CreateWindowAux::new(),
-        )
-        .ok()?;
-        conn.convert_selection(window, clipboard, targets, property, x11rb::CURRENT_TIME)
-            .ok()?;
-        conn.flush().ok()?;
-
-        let deadline = Instant::now() + TIMEOUT;
-        loop {
-            match conn.poll_for_event().ok()? {
-                Some(Event::SelectionNotify(event)) if event.requestor == window => {
-                    // No property means nobody owns the clipboard, or the
-                    // owner won't say what it offers.
-                    if event.property == x11rb::NONE {
-                        return Some(false);
-                    }
-                    break;
+    impl Changes {
+        pub fn listen() -> Option<Self> {
+            if env::var_os("WAYLAND_DISPLAY").is_some() {
+                if let Some(changes) = wayland::Changes::listen() {
+                    return Some(Self::Wayland(changes));
                 }
-                Some(_) => {}
-                None if Instant::now() < deadline => thread::sleep(Duration::from_millis(5)),
-                None => return None,
+            }
+            x11::Changes::listen().map(|changes| Self::X11(Box::new(changes)))
+        }
+
+        pub fn name(&self) -> &'static str {
+            match self {
+                Self::Wayland(_) => "Wayland data-control",
+                Self::X11(_) => "X11 XFixes",
             }
         }
-        let reply = conn
-            .get_property(true, window, property, AtomEnum::ATOM, 0, u32::MAX)
-            .ok()?
-            .reply()
+
+        /// Blocks until the clipboard changes. Returns false once
+        /// announcements stop coming, say because the connection broke.
+        pub fn wait(&mut self) -> bool {
+            match self {
+                Self::Wayland(changes) => changes.wait(),
+                Self::X11(changes) => changes.wait(),
+            }
+        }
+    }
+
+    mod x11 {
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        use x11rb::connection::Connection;
+        use x11rb::protocol::xfixes::{ConnectionExt as _, SelectionEventMask};
+        use x11rb::protocol::xproto::{
+            AtomEnum, ConnectionExt as _, CreateWindowAux, Window, WindowClass,
+        };
+        use x11rb::protocol::Event;
+        use x11rb::rust_connection::RustConnection;
+
+        /// How long the clipboard's owner gets to list what it offers.
+        const TIMEOUT: Duration = Duration::from_millis(500);
+
+        /// Connects, and makes a window to receive selections and events.
+        fn connect() -> Option<(RustConnection, Window)> {
+            let (conn, screen) = x11rb::connect(None).ok()?;
+            let window = conn.generate_id().ok()?;
+            let root = conn.setup().roots.get(screen)?.root;
+            conn.create_window(
+                x11rb::COPY_DEPTH_FROM_PARENT,
+                window,
+                root,
+                0,
+                0,
+                1,
+                1,
+                0,
+                WindowClass::INPUT_ONLY,
+                x11rb::COPY_FROM_PARENT,
+                &CreateWindowAux::new(),
+            )
             .ok()?;
-        let offered = reply.value32()?.any(|offered| offered == target);
-        Some(offered)
+            Some((conn, window))
+        }
+
+        fn atom(conn: &RustConnection, name: &str, only_if_exists: bool) -> Option<u32> {
+            let cookie = conn.intern_atom(only_if_exists, name.as_bytes()).ok()?;
+            Some(cookie.reply().ok()?.atom)
+        }
+
+        /// Whether the clipboard's owner lists `target` among the formats it
+        /// offers.
+        pub fn offers(target: &str) -> Option<bool> {
+            let (conn, window) = connect()?;
+            // Nobody can offer a format that no program has named.
+            let target = atom(&conn, target, true)?;
+            if target == x11rb::NONE {
+                return Some(false);
+            }
+            let clipboard = atom(&conn, "CLIPBOARD", false)?;
+            let targets = atom(&conn, "TARGETS", false)?;
+            let property = atom(&conn, "CB_TARGETS", false)?;
+            conn.convert_selection(window, clipboard, targets, property, x11rb::CURRENT_TIME)
+                .ok()?;
+            conn.flush().ok()?;
+
+            let deadline = Instant::now() + TIMEOUT;
+            loop {
+                match conn.poll_for_event().ok()? {
+                    Some(Event::SelectionNotify(event)) if event.requestor == window => {
+                        // No property means nobody owns the clipboard, or the
+                        // owner won't say what it offers.
+                        if event.property == x11rb::NONE {
+                            return Some(false);
+                        }
+                        break;
+                    }
+                    Some(_) => {}
+                    None if Instant::now() < deadline => thread::sleep(Duration::from_millis(5)),
+                    None => return None,
+                }
+            }
+            let reply = conn
+                .get_property(true, window, property, AtomEnum::ATOM, 0, u32::MAX)
+                .ok()?
+                .reply()
+                .ok()?;
+            let offered = reply.value32()?.any(|offered| offered == target);
+            Some(offered)
+        }
+
+        pub struct Changes {
+            conn: RustConnection,
+        }
+
+        impl Changes {
+            pub fn listen() -> Option<Self> {
+                let (conn, window) = connect()?;
+                // XFixes has to be asked for by version before it's used.
+                conn.xfixes_query_version(5, 0).ok()?.reply().ok()?;
+                let clipboard = atom(&conn, "CLIPBOARD", false)?;
+                // A new owner, or the old one going away, which empties it.
+                let events = SelectionEventMask::SET_SELECTION_OWNER
+                    | SelectionEventMask::SELECTION_WINDOW_DESTROY
+                    | SelectionEventMask::SELECTION_CLIENT_CLOSE;
+                conn.xfixes_select_selection_input(window, clipboard, events)
+                    .ok()?;
+                conn.flush().ok()?;
+                Some(Self { conn })
+            }
+
+            pub fn wait(&mut self) -> bool {
+                loop {
+                    match self.conn.wait_for_event() {
+                        Ok(Event::XfixesSelectionNotify(_)) => return true,
+                        Ok(_) => {}
+                        Err(_) => return false,
+                    }
+                }
+            }
+        }
+    }
+
+    mod wayland {
+        use wayland_client::globals::{registry_queue_init, GlobalListContents};
+        use wayland_client::protocol::wl_registry::WlRegistry;
+        use wayland_client::protocol::wl_seat::WlSeat;
+        use wayland_client::{
+            event_created_child, Connection, Dispatch, EventQueue, Proxy, QueueHandle,
+        };
+        use wayland_protocols::ext::data_control::v1::client::{
+            ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
+            ext_data_control_manager_v1::ExtDataControlManagerV1,
+            ext_data_control_offer_v1::ExtDataControlOfferV1,
+        };
+        use wayland_protocols_wlr::data_control::v1::client::{
+            zwlr_data_control_device_v1::{self, ZwlrDataControlDeviceV1},
+            zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+            zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,
+        };
+
+        /// What the event handlers tell `wait`.
+        #[derive(Default)]
+        struct State {
+            changed: bool,
+            /// The compositor retired our data-control device.
+            finished: bool,
+        }
+
+        pub struct Changes {
+            queue: EventQueue<State>,
+            state: State,
+            _conn: Connection,
+        }
+
+        impl Changes {
+            pub fn listen() -> Option<Self> {
+                let conn = Connection::connect_to_env().ok()?;
+                let (globals, mut queue) = registry_queue_init::<State>(&conn).ok()?;
+                let qh = queue.handle();
+                let seat: WlSeat = globals.bind(&qh, 1..=2, ()).ok()?;
+                // ext-data-control is the standard; wlr-data-control is what
+                // came before it, and some compositors still only have that.
+                match globals.bind::<ExtDataControlManagerV1, _, _>(&qh, 1..=1, ()) {
+                    Ok(manager) => {
+                        manager.get_data_device(&seat, &qh, ());
+                    }
+                    Err(_) => {
+                        let manager: ZwlrDataControlManagerV1 =
+                            globals.bind(&qh, 1..=2, ()).ok()?;
+                        manager.get_data_device(&seat, &qh, ());
+                    }
+                }
+                let mut state = State::default();
+                // Have the compositor take all that in before relying on it.
+                queue.roundtrip(&mut state).ok()?;
+                if state.finished {
+                    return None;
+                }
+                Some(Self {
+                    queue,
+                    state,
+                    _conn: conn,
+                })
+            }
+
+            pub fn wait(&mut self) -> bool {
+                self.state.changed = false;
+                while !self.state.changed {
+                    if self.state.finished || self.queue.blocking_dispatch(&mut self.state).is_err()
+                    {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+
+        /// Handlers for objects whose events don't matter here.
+        macro_rules! ignore_events {
+            ($($interface:ty => $data:ty),* $(,)?) => {$(
+                impl Dispatch<$interface, $data> for State {
+                    fn event(
+                        _: &mut Self,
+                        _: &$interface,
+                        _: <$interface as Proxy>::Event,
+                        _: &$data,
+                        _: &Connection,
+                        _: &QueueHandle<Self>,
+                    ) {
+                    }
+                }
+            )*};
+        }
+
+        ignore_events!(
+            WlRegistry => GlobalListContents,
+            WlSeat => (),
+            ExtDataControlManagerV1 => (),
+            ZwlrDataControlManagerV1 => (),
+            ExtDataControlOfferV1 => (),
+            ZwlrDataControlOfferV1 => (),
+        );
+
+        /// The two protocols' devices differ only in name.
+        macro_rules! handle_device {
+            ($device:ty, $module:ident, $offer:ty) => {
+                impl Dispatch<$device, ()> for State {
+                    fn event(
+                        state: &mut Self,
+                        _: &$device,
+                        event: $module::Event,
+                        _: &(),
+                        _: &Connection,
+                        _: &QueueHandle<Self>,
+                    ) {
+                        match event {
+                            // arboard reads the clipboard itself, so the
+                            // offers that come with these can go.
+                            $module::Event::Selection { id } => {
+                                if let Some(offer) = id {
+                                    offer.destroy();
+                                }
+                                state.changed = true;
+                            }
+                            $module::Event::PrimarySelection { id: Some(offer) } => {
+                                offer.destroy();
+                            }
+                            $module::Event::Finished => state.finished = true,
+                            _ => {}
+                        }
+                    }
+
+                    event_created_child!(State, $device, [
+                        $module::EVT_DATA_OFFER_OPCODE => ($offer, ()),
+                    ]);
+                }
+            };
+        }
+
+        handle_device!(
+            ExtDataControlDeviceV1,
+            ext_data_control_device_v1,
+            ExtDataControlOfferV1
+        );
+        handle_device!(
+            ZwlrDataControlDeviceV1,
+            zwlr_data_control_device_v1,
+            ZwlrDataControlOfferV1
+        );
     }
 }
 
@@ -128,6 +358,24 @@ mod imp {
         Some(NSPasteboard::generalPasteboard().changeCount() as u64)
     }
 
+    /// macOS doesn't announce clipboard changes; its change count is how
+    /// they're found instead.
+    pub struct Changes;
+
+    impl Changes {
+        pub fn listen() -> Option<Self> {
+            None
+        }
+
+        pub fn name(&self) -> &'static str {
+            unreachable!("macOS has no clipboard notifications")
+        }
+
+        pub fn wait(&mut self) -> bool {
+            false
+        }
+    }
+
     pub fn is_concealed() -> bool {
         let Some(types) = NSPasteboard::generalPasteboard().types() else {
             return false;
@@ -141,6 +389,7 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
+    use clipboard_win::monitor::Monitor;
     use clipboard_win::raw::{is_format_avail, register_format, seq_num};
 
     /// Formats that password managers add to keep a copy out of clipboard
@@ -154,6 +403,24 @@ mod imp {
 
     pub fn change_count() -> Option<u64> {
         seq_num().map(|number| number.get().into())
+    }
+
+    /// Windows sends a message to listeners registered with
+    /// `AddClipboardFormatListener` whenever the clipboard changes.
+    pub struct Changes(Monitor);
+
+    impl Changes {
+        pub fn listen() -> Option<Self> {
+            Monitor::new().ok().map(Self)
+        }
+
+        pub fn name(&self) -> &'static str {
+            "clipboard notifications"
+        }
+
+        pub fn wait(&mut self) -> bool {
+            matches!(self.0.recv(), Ok(true))
+        }
     }
 
     pub fn is_concealed() -> bool {
@@ -179,5 +446,21 @@ mod imp {
 
     pub fn is_concealed() -> bool {
         false
+    }
+
+    pub struct Changes;
+
+    impl Changes {
+        pub fn listen() -> Option<Self> {
+            None
+        }
+
+        pub fn name(&self) -> &'static str {
+            unreachable!("no clipboard notifications here")
+        }
+
+        pub fn wait(&mut self) -> bool {
+            false
+        }
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -13,7 +13,8 @@ use arboard::Clipboard;
 use crate::history::{self, Use};
 use crate::{platform, remember};
 
-/// How often to look at the clipboard.
+/// How often to look at the clipboard where the platform doesn't say when it
+/// changes.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Watches the clipboard until stopped, adding each new copy to history.
@@ -30,37 +31,80 @@ pub fn run() -> Result<(), String> {
         process::exit(0);
     })
     .map_err(|e| format!("{}: {}", address.display(), e))?;
-    eprintln!("cb: watching the clipboard; press Ctrl-C to stop");
+    let mut changes = platform::Changes::listen();
+    match &changes {
+        Some(changes) => eprintln!(
+            "cb: watching the clipboard through {}; press Ctrl-C to stop",
+            changes.name()
+        ),
+        None => eprintln!(
+            "cb: watching the clipboard, checking every {} seconds; press Ctrl-C to stop",
+            POLL_INTERVAL.as_secs()
+        ),
+    }
     hide_console();
 
     let mut watcher = Watcher::default();
-    let mut seen_change = None;
+    let mut count = platform::change_count();
     loop {
-        let change = platform::change_count();
-        if change.is_none() || change != seen_change {
-            match clipboard.get_text() {
-                Ok(text) => {
-                    seen_change = change;
-                    if watcher.observe(Some(&text), platform::is_concealed) {
-                        remember(&text, None, Use::Seen);
-                    }
+        check(&mut clipboard, &mut watcher);
+        match changes.as_mut() {
+            Some(listener) => {
+                if !listener.wait() {
+                    eprintln!(
+                        "cb: clipboard notifications stopped; checking every {} seconds instead",
+                        POLL_INTERVAL.as_secs()
+                    );
+                    changes = None;
                 }
-                // Empty, or holding something other than text.
-                Err(arboard::Error::ContentNotAvailable) => {
-                    seen_change = change;
-                    watcher.observe(None, || false);
+            }
+            None => poll(&mut count),
+        }
+    }
+}
+
+/// Reads the clipboard, and records it if it holds a new copy.
+fn check(clipboard: &mut Clipboard, watcher: &mut Watcher) {
+    // Right after a copy, the clipboard can be busy: on Windows, other
+    // programs open it to read it too. With nothing prompting a later look,
+    // give it a few tries before letting this change go.
+    for attempt in 0..5 {
+        match clipboard.get_text() {
+            Ok(text) => {
+                if watcher.observe(Some(&text), platform::is_concealed) {
+                    remember(&text, None, Use::Seen);
                 }
-                // Another program may have the clipboard open, as happens on
-                // Windows, or the connection to the display may have broken.
-                // Look again next time, with a fresh connection.
-                Err(_) => {
-                    if let Ok(fresh) = Clipboard::new() {
-                        clipboard = fresh;
-                    }
+                return;
+            }
+            // Empty, or holding something other than text.
+            Err(arboard::Error::ContentNotAvailable) => {
+                watcher.observe(None, || false);
+                return;
+            }
+            // The connection to the display may have broken too, so the next
+            // try gets a fresh one.
+            Err(_) => {
+                thread::sleep(Duration::from_millis(100 << attempt));
+                if let Ok(fresh) = Clipboard::new() {
+                    *clipboard = fresh;
                 }
             }
         }
+    }
+}
+
+/// Sleeps until the clipboard may have changed, looking every
+/// `POLL_INTERVAL`. Where the platform counts changes, as macOS and Windows
+/// do, the count is what's looked at, and the clipboard is only read when it
+/// moves.
+fn poll(count: &mut Option<u64>) {
+    loop {
         thread::sleep(POLL_INTERVAL);
+        let now = platform::change_count();
+        if now.is_none() || now != *count {
+            *count = now;
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`cb watch` now waits for the system to announce clipboard changes, where the system does that, instead of checking every 2 seconds. Copies made in quick succession are no longer missed, and the watcher does nothing between copies. Where there are no announcements it still polls every 2 seconds.

**Stacked on #25 (itself on #24):** merge #24, then #25, then this.

| Platform | How changes are detected |
| --- | --- |
| Linux, Wayland with data-control (KDE, sway, Hyprland, …) | `selection` events from `ext-data-control-v1`, or `wlr-data-control` where that's all there is |
| Linux, X11 or XWayland (including GNOME, which has no data-control) | XFixes selection events: a new owner, or the owner going away |
| Windows | `WM_CLIPBOARDUPDATE`, via clipboard-win's `monitor` (`AddClipboardFormatListener`) |
| macOS | No notification API exists, so it polls `NSPasteboard.changeCount` every 2 seconds and reads the clipboard only when the count moves |

- **Choosing a listener:** Linux prefers Wayland data-control when it's available, because that's also where arboard reads the clipboard.
- **Fallback:** if no listener can be set up, or notifications stop (the connection breaks, or the compositor retires the data-control device), the watcher goes back to 2-second polling. It says which method it's using when it starts.
- **Retries:** after a notification, a failed read is retried with backoff (100 ms up to 1.6 s). On Windows, other programs open the clipboard right after a copy too, and without polling there's no later check to catch a missed read.
- **Dependencies:**
  - x11rb gains its `xfixes` feature.
  - `wayland-client`, `wayland-protocols` and `wayland-protocols-wlr` become direct dependencies; they were already in the tree through wl-clipboard-rs.
  - clipboard-win's `monitor` feature adds one new crate, `windows-win`, on Windows only.
- `--help`, completions, README and man page are updated.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` are clean: 82 tests. There are no new unit tests, because the listeners need a real display server.
- End to end on Linux (GNOME on Wayland), against the real clipboard, with temp history and config:
  - The watcher reported `watching the clipboard through X11 XFixes`, which is the expected path on GNOME.
  - Three copies made 0.3 seconds apart were all recorded; 2-second polling would have missed the middle ones.
  - The earlier checks all pass again: copies from other programs and from `cb` are recorded, a copy marked with `x-kde-passwordManagerHint` is skipped, a second watcher exits, and `--install`/`--uninstall` start and stop exactly one watcher. The watcher used about 0.08% CPU.
- **Not tested at runtime:** the Wayland data-control listener (no compositor with it here), the Windows monitor, and macOS. CI compiles all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan
