### PR TITLE
fix: pass CB_HISTORY_FILE to cb watch started at login

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ cb watch               # or run it in the foreground; Ctrl-C stops it
 (`~/Library/LaunchAgents/com.github.amilajack.cb.watch.plist`), and an entry
 under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` on Windows. The
 entry runs the `cb` you installed it with, so install again if you move `cb`.
+If `CB_HISTORY_FILE` is set when you install, the entry passes it on. On
+Windows, where a login entry can't, set it for your account with `setx` first.
 Window managers without desktop autostart, like sway and i3, need `cb watch`
 started from their config instead. Only one watcher runs at a time.
 

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -94,6 +94,8 @@ This adds \f[I]\[ti]/.config/autostart/cb\-watch.desktop\f[R] on Linux,
 on macOS, and a \f[I]cb watch\f[R] value under
 \f[I]HKCU\[rs]Software\[rs]Microsoft\[rs]Windows\[rs]CurrentVersion\[rs]Run\f[R]
 on Windows, each running the \f[B]cb\f[R] it was installed with.
+If \f[B]CB_HISTORY_FILE\f[R] is set, the entry passes it on; on Windows,
+where it can't, it has to be set for the account, as \f[B]setx\f[R] does.
 .TP
 \f[B]\-\-uninstall\f[R]
 Remove what \f[B]\-\-install\f[R] added, and stop the running watcher.

--- a/src/history.rs
+++ b/src/history.rs
@@ -86,7 +86,9 @@ pub fn require_path() -> Result<PathBuf, String> {
 fn resolve_path(overridden: Option<OsString>) -> Option<PathBuf> {
     match overridden {
         Some(path) if path.is_empty() => None,
-        Some(path) => Some(PathBuf::from(path)),
+        // Made absolute, so that cb and a watcher started at login, in
+        // another directory, agree on which file it is.
+        Some(path) => Some(std::path::absolute(&path).unwrap_or_else(|_| PathBuf::from(path))),
         None => dirs::data_dir().map(|dir| dir.join("cb").join("history.jsonl")),
     }
 }
@@ -368,7 +370,7 @@ mod tests {
         assert_eq!(resolve_path(Some("".into())), None);
         assert_eq!(
             resolve_path(Some("h.jsonl".into())),
-            Some(PathBuf::from("h.jsonl"))
+            Some(env::current_dir().unwrap().join("h.jsonl"))
         );
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -110,9 +110,13 @@ fn poll(count: &mut Option<u64>) {
 
 /// Makes `cb watch` start at login, and starts it now.
 pub fn install() -> Result<(), String> {
-    let address = control::address(&history::require_path()?);
+    let history = history::require_path()?;
+    let address = control::address(&history);
     let exe = env::current_exe().map_err(|e| e.to_string())?;
-    println!("{}", autostart::install(&exe)?);
+    // Programs started at login don't see variables set in a shell, so a
+    // history file other than the default has to be passed along.
+    let custom = env::var_os(history::HISTORY_ENV).map(|_| history.as_path());
+    println!("{}", autostart::install(&exe, custom)?);
     if control::is_running(&address) {
         println!("Already watching the clipboard");
         return Ok(());
@@ -338,16 +342,28 @@ mod autostart {
         )),
         allow(dead_code)
     )]
-    pub fn desktop_entry(exe: &Path) -> String {
+    pub fn desktop_entry(exe: &Path, history: Option<&Path>) -> String {
+        let environment = match history {
+            Some(history) => format!(
+                "env {} ",
+                exec_quote(&format!(
+                    "{}={}",
+                    history::HISTORY_ENV,
+                    history.to_string_lossy()
+                ))
+            ),
+            None => String::new(),
+        };
         format!(
             "[Desktop Entry]\n\
              Type=Application\n\
              Name=cb clipboard history\n\
              Comment=Records what you copy, for cb peek\n\
-             Exec={} watch\n\
+             Exec={}{} watch\n\
              Terminal=false\n\
              NoDisplay=true\n\
              X-GNOME-Autostart-enabled=true\n",
+            environment,
             exec_quote(&exe.to_string_lossy())
         )
     }
@@ -381,7 +397,16 @@ mod autostart {
     /// A launchd agent that starts the watcher at login, and again if it
     /// fails, but not after it's been stopped.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-    pub fn launch_agent(label: &str, exe: &Path) -> String {
+    pub fn launch_agent(label: &str, exe: &Path, history: Option<&Path>) -> String {
+        let environment = match history {
+            Some(history) => format!(
+                "    <key>EnvironmentVariables</key>\n    <dict>\n        \
+                 <key>{}</key>\n        <string>{}</string>\n    </dict>\n",
+                history::HISTORY_ENV,
+                xml_escape(&history.to_string_lossy())
+            ),
+            None => String::new(),
+        };
         format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -394,7 +419,7 @@ mod autostart {
         <string>{}</string>
         <string>watch</string>
     </array>
-    <key>RunAtLoad</key>
+{}    <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <dict>
@@ -409,7 +434,8 @@ mod autostart {
 </plist>
 "#,
             xml_escape(label),
-            xml_escape(&exe.to_string_lossy())
+            xml_escape(&exe.to_string_lossy()),
+            environment
         )
     }
 
@@ -446,13 +472,13 @@ mod autostart {
         unix,
         not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
     ))]
-    fn entry(exe: &Path) -> String {
-        desktop_entry(exe)
+    fn entry(exe: &Path, history: Option<&Path>) -> String {
+        desktop_entry(exe, history)
     }
 
     #[cfg(target_os = "macos")]
-    fn entry(exe: &Path) -> String {
-        launch_agent(LAUNCH_AGENT, exe)
+    fn entry(exe: &Path, history: Option<&Path>) -> String {
+        launch_agent(LAUNCH_AGENT, exe, history)
     }
 
     /// Returns what it did, for the user.
@@ -463,13 +489,13 @@ mod autostart {
             not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
         )
     ))]
-    pub fn install(exe: &Path) -> Result<String, String> {
+    pub fn install(exe: &Path, history: Option<&Path>) -> Result<String, String> {
         let path = entry_path()?;
         let context = |e: io::Error| format!("{}: {}", path.display(), e);
         if let Some(dir) = path.parent() {
             fs::create_dir_all(dir).map_err(context)?;
         }
-        fs::write(&path, entry(exe)).map_err(context)?;
+        fs::write(&path, entry(exe, history)).map_err(context)?;
         Ok(format!("Added {}", path.display()))
     }
 
@@ -496,8 +522,28 @@ mod autostart {
     const RUN_VALUE: &str = "cb watch";
 
     #[cfg(windows)]
-    pub fn install(exe: &Path) -> Result<String, String> {
+    pub fn install(exe: &Path, history: Option<&Path>) -> Result<String, String> {
         use std::os::windows::process::CommandExt;
+
+        // A Run entry can't set variables, so the watcher it starts only uses
+        // a custom history file if the variable is set for the account.
+        if let Some(history) = history {
+            let set_for_account = Command::new("reg")
+                .args(["query", r"HKCU\Environment", "/v", history::HISTORY_ENV])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success());
+            if !set_for_account {
+                return Err(format!(
+                    "programs started at login won't see {0}; set it for your \
+                     account with `setx {0} \"{1}\"`, then run this again in a new \
+                     terminal",
+                    history::HISTORY_ENV,
+                    history.display()
+                ));
+            }
+        }
 
         // reg takes quotes inside the value escaped with backslashes;
         // `raw_arg` keeps std from quoting them all over again.
@@ -528,7 +574,7 @@ mod autostart {
     }
 
     #[cfg(not(any(unix, windows)))]
-    pub fn install(_exe: &Path) -> Result<String, String> {
+    pub fn install(_exe: &Path, _history: Option<&Path>) -> Result<String, String> {
         Err("starting at login isn't supported here".to_owned())
     }
 
@@ -538,7 +584,7 @@ mod autostart {
     }
 
     #[cfg(any(target_os = "android", target_os = "emscripten"))]
-    pub fn install(_exe: &Path) -> Result<String, String> {
+    pub fn install(_exe: &Path, _history: Option<&Path>) -> Result<String, String> {
         Err("starting at login isn't supported here".to_owned())
     }
 
@@ -617,7 +663,7 @@ mod tests {
 
     #[test]
     fn desktop_entries_quote_the_path() {
-        let entry = autostart::desktop_entry(Path::new("/home/a b/c$d\"e\\f%g"));
+        let entry = autostart::desktop_entry(Path::new("/home/a b/c$d\"e\\f%g"), None);
         assert!(
             entry.contains(r#"Exec="/home/a b/c\\$d\\"e\\\\f%%g" watch"#),
             "{}",
@@ -628,12 +674,46 @@ mod tests {
 
     #[test]
     fn launch_agents_escape_the_path() {
-        let agent = autostart::launch_agent("x", Path::new("/Users/a&b/<cb>"));
+        let agent = autostart::launch_agent("x", Path::new("/Users/a&b/<cb>"), None);
         assert!(
             agent.contains("<string>/Users/a&amp;b/&lt;cb&gt;</string>"),
             "{}",
             agent
         );
         assert!(agent.contains("<key>RunAtLoad</key>\n    <true/>"));
+        assert!(!agent.contains("EnvironmentVariables"));
+    }
+
+    #[test]
+    fn desktop_entries_pass_on_a_custom_history_file() {
+        let entry = autostart::desktop_entry(
+            Path::new("/usr/bin/cb"),
+            Some(Path::new("/home/a/my history.jsonl")),
+        );
+        assert!(
+            entry.contains(
+                r#"Exec=env "CB_HISTORY_FILE=/home/a/my history.jsonl" "/usr/bin/cb" watch"#
+            ),
+            "{}",
+            entry
+        );
+    }
+
+    #[test]
+    fn launch_agents_pass_on_a_custom_history_file() {
+        let agent = autostart::launch_agent(
+            "x",
+            Path::new("/usr/local/bin/cb"),
+            Some(Path::new("/Users/a/h&b.jsonl")),
+        );
+        assert!(
+            agent.contains(
+                "    </array>\n    <key>EnvironmentVariables</key>\n    <dict>\n        \
+                 <key>CB_HISTORY_FILE</key>\n        <string>/Users/a/h&amp;b.jsonl</string>\n    \
+                 </dict>\n    <key>RunAtLoad</key>"
+            ),
+            "{}",
+            agent
+        );
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -121,7 +121,7 @@ pub fn install() -> Result<(), String> {
         println!("Already watching the clipboard");
         return Ok(());
     }
-    start_in_background(&exe).map_err(|e| format!("failed to start cb watch: {}", e))?;
+    start_in_background(&exe, custom).map_err(|e| format!("failed to start cb watch: {}", e))?;
     // Wait for it to answer, so that a watcher that can't start, say for
     // want of a display, is reported here rather than failing silently.
     for _ in 0..30 {
@@ -146,13 +146,18 @@ pub fn uninstall() -> Result<(), String> {
     Ok(())
 }
 
-fn start_in_background(exe: &Path) -> io::Result<()> {
+/// Starts `cb watch` on its own. It runs from `/`, so a custom history file
+/// is passed as the absolute path, not as given.
+fn start_in_background(exe: &Path, custom: Option<&Path>) -> io::Result<()> {
     let mut command = Command::new(exe);
     command
         .arg("watch")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    if let Some(custom) = custom {
+        command.env(history::HISTORY_ENV, custom);
+    }
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;


### PR DESCRIPTION
## Summary

Fixes the login watcher ignoring `CB_HISTORY_FILE`, found while reviewing #24.

**The problem:** the login entries that `cb watch --install` writes started `cb watch` without `CB_HISTORY_FILE`, and a value set in a shell config doesn't reach programs started at login. With a custom history file:
- After the next login, the watcher recorded into the default history, so `cb peek` never showed those copies.
- The control address is derived from the history path, so shell commands looked in the wrong place: `--uninstall` couldn't stop the login watcher, and `--install` started a second one.

**The fix:** when `CB_HISTORY_FILE` is set during `--install`, the login entry passes it along.

| Platform | How |
| --- | --- |
| Linux | `Exec=env "CB_HISTORY_FILE=…" "/path/to/cb" watch` in the desktop entry |
| macOS | `EnvironmentVariables` in the LaunchAgent |
| Windows | A Run entry can't set variables. `--install` checks the variable is set for the account (`HKCU\Environment`, which is what `setx` writes). If it isn't, it refuses and prints the `setx` command, instead of letting the login watcher silently use another file. |

**Relative paths:** a relative `CB_HISTORY_FILE` is now made absolute. A login watcher starts in a different directory, and `cb` and the watcher must agree on the file, and therefore on its control address. The watcher that `--install` starts right away gets the absolute path too, since it runs from `/`.

README and man page are updated.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` are clean: 84 tests, with 2 new and 1 updated.
  - **New:** the desktop entry's `env` prefix, including a path with a space, and the LaunchAgent's `EnvironmentVariables`, including XML escaping.
  - **Updated:** a relative override now resolves to an absolute path.
- End to end on Linux, with a relative `CB_HISTORY_FILE`:
  - `--install` wrote `Exec=env "CB_HISTORY_FILE=<absolute path>" "…/cb" watch` and found the watcher it had started.
  - `--uninstall`, run from `/` with the absolute path, stopped that watcher.
  - Running the entry's `Exec` command from `/`, as a login would, started a watcher that `--uninstall` stopped from the original directory using the relative path.
- **Not run:** the Windows `reg query` check and the macOS agent. CI compiles both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan
