### PR TITLE
fix: keep cb and cb watch from overwriting each other's history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "clipboard-win",
  "crossterm",
  "dirs",
+ "fs4",
  "objc2-app-kit",
  "objc2-foundation",
  "ratatui",
@@ -378,6 +379,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "gethostname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 arboard = { version = "3.6", default-features = false, features = ["wayland-data-control"] }
 crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
 dirs = "6.0"
+fs4 = { version = "1.1", default-features = false, features = ["sync"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29", "layout-cache"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ unused. What you copy often stays near the top, and old favorites sink within
 days. Matches keep that order as you search, which is case-sensitive only if it
 contains an uppercase letter.
 
-History holds the last 500 copies, up to 1 MiB each, in a file only you can
-read: `~/.local/share/cb/history.jsonl` on Linux,
+History holds the last 500 copies, up to 1 MiB each and 10 MiB in all, in a
+file only you can read: `~/.local/share/cb/history.jsonl` on Linux,
 `~/Library/Application Support/cb/history.jsonl` on macOS, and
 `%APPDATA%\cb\history.jsonl` on Windows. Set `CB_HISTORY_FILE` to keep it
 somewhere else, or to an empty string to turn history off. The preview theme

--- a/doc/cb.1
+++ b/doc/cb.1
@@ -27,7 +27,8 @@ copied text until another program copies something.
 \f[B]cb\f[R] keeps a history of what it copies, and of what it finds on
 the clipboard when printing it.
 \f[B]cb watch\f[R] adds everything copied in any program.
-History holds the last 500 copies of up to 1 MiB each.
+History holds the last 500 copies of up to 1 MiB each, and 10 MiB in
+all.
 Copies that password managers mark as secret are never recorded: those
 offering the \f[I]x\-kde\-passwordManagerHint\f[R] type on Linux, the
 nspasteboard.org types on macOS, or

--- a/src/history.rs
+++ b/src/history.rs
@@ -7,6 +7,7 @@ use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
 /// Where to keep history instead of the platform's data directory. An empty
@@ -18,6 +19,10 @@ const MAX_ENTRIES: usize = 500;
 
 /// Larger copies aren't kept, so that reading history stays fast.
 const MAX_ENTRY_BYTES: usize = 1024 * 1024;
+
+/// The oldest entries go once history grows past this, since every copy
+/// rereads and rewrites the whole file.
+const MAX_HISTORY_BYTES: usize = 10 * 1024 * 1024;
 
 /// How long an unused entry takes to lose half its frecency, in seconds.
 const HALF_LIFE: u64 = 24 * 60 * 60;
@@ -104,10 +109,27 @@ pub fn record(text: &str, source: Option<&Path>, how: Use) -> Result<(), String>
     };
     let source =
         source.map(|source| fs::canonicalize(source).unwrap_or_else(|_| source.to_owned()));
-    let context = |e: io::Error| format!("{}: {}", path.display(), e);
-    let mut entries = load(&path).map_err(context)?;
-    if push(&mut entries, text, source, how, now()) {
-        save(&path, &entries).map_err(context)
+    update(&path, |entries| push(entries, text, source, how, now()))
+        .map_err(|e| format!("{}: {}", path.display(), e))
+}
+
+/// Applies `change` to the history at `path`, saving it if `change` says it
+/// changed anything. A lock is held throughout: `cb watch` and the cb that
+/// just copied something often write at the same moment, and without it one
+/// would overwrite the other's change.
+fn update(path: &Path, change: impl FnOnce(&mut Vec<Entry>) -> bool) -> io::Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    // A file of its own, since saving replaces the history file. The lock is
+    // released when it's closed.
+    let lock = private()
+        .truncate(false)
+        .open(path.with_extension("lock"))?;
+    FileExt::lock(&lock)?;
+    let mut entries = load(path)?;
+    if change(&mut entries) {
+        save(path, &entries)
     } else {
         Ok(())
     }
@@ -132,8 +154,9 @@ pub fn load(path: &Path) -> io::Result<Vec<Entry>> {
 
 /// Records a use of `text` at `now` as the newest entry, carrying over the
 /// uses and frecency of any earlier entry for the same text, and drops the
-/// oldest entries past the limit. Returns whether anything changed: empty and
-/// oversized text isn't kept, and seeing the newest entry again isn't a use.
+/// oldest entries past the limits. Returns whether anything changed: empty
+/// and oversized text isn't kept, and seeing the newest entry again isn't a
+/// use.
 fn push(entries: &mut Vec<Entry>, text: &str, source: Option<PathBuf>, how: Use, now: u64) -> bool {
     if text.is_empty() || text.len() > MAX_ENTRY_BYTES {
         return false;
@@ -157,9 +180,18 @@ fn push(entries: &mut Vec<Entry>, text: &str, source: Option<PathBuf>, how: Use,
         entry.source = entry.source.or(old.source);
     }
     entries.push(entry);
-    if entries.len() > MAX_ENTRIES {
-        entries.drain(..entries.len() - MAX_ENTRIES);
+
+    let mut dropped = entries.len().saturating_sub(MAX_ENTRIES);
+    let mut size: usize = entries[dropped..]
+        .iter()
+        .map(|entry| entry.text.len())
+        .sum();
+    // The newest entry is never over the limit on its own, so it stays.
+    while size > MAX_HISTORY_BYTES {
+        size -= entries[dropped].text.len();
+        dropped += 1;
     }
+    entries.drain(..dropped);
     true
 }
 
@@ -177,7 +209,7 @@ fn save(path: &Path, entries: &[Entry]) -> io::Result<()> {
 }
 
 fn write_entries(path: &Path, entries: &[Entry]) -> io::Result<()> {
-    let mut out = BufWriter::new(create_private(path)?);
+    let mut out = BufWriter::new(private().truncate(true).open(path)?);
     for entry in entries {
         serde_json::to_writer(&mut out, entry)?;
         out.write_all(b"\n")?;
@@ -185,16 +217,17 @@ fn write_entries(path: &Path, entries: &[Entry]) -> io::Result<()> {
     out.flush()
 }
 
-/// History can hold passwords and tokens, so only its owner may read it.
-fn create_private(path: &Path) -> io::Result<File> {
+/// Options for creating files only their owner can read, since history can
+/// hold passwords and tokens.
+fn private() -> OpenOptions {
     let mut options = OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    options.open(path)
+    options
 }
 
 #[cfg(test)]
@@ -296,6 +329,18 @@ mod tests {
     }
 
     #[test]
+    fn push_drops_the_oldest_entries_past_the_size_limit() {
+        let big = |i: u64| entry(&format!("{}{}", i, "x".repeat(MAX_ENTRY_BYTES - 8)), i);
+        let mut entries: Vec<_> = (0..12).map(big).collect();
+        let newest = big(99).text;
+        assert!(push(&mut entries, &newest, None, Use::Copied, 99));
+        let size: usize = entries.iter().map(|entry| entry.text.len()).sum();
+        assert!(size <= MAX_HISTORY_BYTES, "{}", size);
+        assert_eq!(entries.len(), MAX_HISTORY_BYTES / MAX_ENTRY_BYTES);
+        assert_eq!(entries.last().unwrap().text, newest);
+    }
+
+    #[test]
     fn frecency_halves_every_day_unused() {
         let a = Entry {
             score: 4.0,
@@ -331,6 +376,29 @@ mod tests {
         ];
         save(&path, &entries).unwrap();
         assert_eq!(load(&path).unwrap(), entries);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn writers_at_the_same_time_all_land() {
+        let dir = temp_path("concurrent");
+        let path = dir.join("history.jsonl");
+        let writers: Vec<_> = (0..8)
+            .map(|writer| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    for i in 0..25 {
+                        let text = format!("{}-{}", writer, i);
+                        update(&path, |entries| push(entries, &text, None, Use::Copied, 1))
+                            .unwrap();
+                    }
+                })
+            })
+            .collect();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        assert_eq!(load(&path).unwrap().len(), 8 * 25);
         fs::remove_dir_all(dir).unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,9 +153,11 @@ fn run(action: Action) -> Result<(), String> {
             let text =
                 fs::read_to_string(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
             let text = strip_trailing_newline(&text);
-            copy(text)?;
+            // Recorded before copying: `cb watch` hears of a copy as soon as
+            // it's made, and should find it already in history rather than
+            // count it again.
             remember(text, Some(&path), Use::Copied);
-            Ok(())
+            copy(text)
         }
         Action::CopyStdin => {
             let mut text = String::new();
@@ -163,9 +165,8 @@ fn run(action: Action) -> Result<(), String> {
                 .read_to_string(&mut text)
                 .map_err(|e| format!("stdin: {}", e))?;
             let text = strip_trailing_newline(&text);
-            copy(text)?;
             remember(text, None, Use::Copied);
-            Ok(())
+            copy(text)
         }
         Action::Peek => peek(),
         Action::Watch => watch::run(),
@@ -211,9 +212,8 @@ fn peek() -> Result<(), String> {
     let Some(entry) = peek::run(entries, &highlighter).map_err(|e| e.to_string())? else {
         return Ok(());
     };
-    copy(&entry.text)?;
     remember(&entry.text, entry.source.as_deref(), Use::Copied);
-    Ok(())
+    copy(&entry.text)
 }
 
 fn print() -> Result<(), String> {


### PR DESCRIPTION
## Summary

Fixes two history problems found while reviewing #24–#26: `cb` and `cb watch` could write history at the same time, and history had no limit on its total size.

**1. `cb` and the watcher writing at once.** Every write reads the whole history file, changes it and saves it back, with no lock. Once `cb watch` began reacting to clipboard changes within milliseconds (#26), `cb main.rs` and the watcher could both write the same copy together. Two things could go wrong:
- **Lost write:** one write overwrote the other. That could drop the `main.rs` source that gives the preview its syntax highlighting, or occasionally the whole entry.
- **Double count:** the watcher counted a "seen" use and `cb` a "copied" use of the same copy, inflating its frecency.

The fix has two parts:
- **Record first:** `cb` records a copy before putting it on the clipboard. When the watcher hears of the change, the text is already the newest entry, so its sighting doesn't count. This also covers Enter in `cb peek`.
- **Lock:** every read-change-rewrite of history holds an exclusive lock on `history.lock`, a file next to the history file. The history file can't hold the lock itself, because saving replaces it. The lock comes from [`fs4`](https://crates.io/crates/fs4), which adds no new crates to the dependency tree (its `rustix` and `windows-sys` versions were already there). Rust's own `File::lock` needs 1.89, and the project's minimum is 1.86.

**2. History had no total size limit.** It allowed 500 entries of up to 1 MiB each, and every recorded copy rereads and rewrites the whole file. Now that the watcher records everything, the file could reach hundreds of MB. The oldest entries are now dropped once the total passes 10 MiB.

README and man page are updated.

**Tradeoff:** since the copy is recorded first, a copy that then fails, for example over SSH with no display, still ends up in history.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` are clean: 84 tests, 2 of them new.
  - Eight threads each writing 25 entries at once all land, all 200.
  - The oldest entries are dropped past 10 MiB, and the newest is always kept.
- Before this fix, I ran 8 `cb` copies against a live watcher on Linux and couldn't reproduce either problem; on this machine `cb` happens to win the race. The fix removes the race rather than relying on that timing.
- End to end on Linux with this fix and a watcher running: six `cb FILE` copies were each recorded once and kept their source file. `history.lock` was created with mode `0600`.
- Merged locally with #28 and #29: all 88 tests pass, and the earlier end-to-end watch checks pass too, including rapid copies, skipping secrets, install and uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sYq94wetzcpt2mMsBbdan
